### PR TITLE
Support for recent alpaka version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,11 +130,6 @@ example/CMakeLists.txt for an easy to adopt example.
   is used, this library is __not needed__:
   * _From Source_:
     * `git clone https://github.com/ComputationalRadiationPhysics/alpaka.git`
-    * As Alpaka is steady improved, the most recent version of Alpaka does not
-      work with isaac. You need to force git to use a specific (working)
-      version with:
-      * `cd alpaka`
-      * `git checkout e7b18db90cf4cf5fd6d6262adec9db176c3da8af`
     * It is an header only library and doesn't need to be installed. However
       the root directory of the libary has to be added to the CMake Variable
       `CMAKE_MODULE_PATH`, e.g. with

--- a/example/example.cu
+++ b/example/example.cu
@@ -175,6 +175,7 @@ int main(int argc, char **argv)
 		using AccDim = alpaka::dim::DimInt<3>;
 		using SimDim = alpaka::dim::DimInt<3>;
 		using DatDim = alpaka::dim::DimInt<1>;
+
 		//using Acc = alpaka::acc::AccGpuCudaRt<AccDim, size_t>;
 		//using Stream  = alpaka::stream::StreamCudaRtSync;
 		using Acc = alpaka::acc::AccCpuOmp2Blocks<AccDim, size_t>;
@@ -184,9 +185,11 @@ int main(int argc, char **argv)
 
 		using DevAcc = alpaka::dev::Dev<Acc>;
 		using DevHost = alpaka::dev::DevCpu;
+		using PltfHost = alpaka::pltf::Pltf<DevHost>;
+		using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
 
-		DevAcc  devAcc  (alpaka::dev::DevMan<Acc>::getDevByIdx(rank % alpaka::dev::DevMan<Acc>::getDevCount()));
-		DevHost devHost (alpaka::dev::cpu::getDev());
+		DevAcc  devAcc  (alpaka::pltf::getDevByIdx<PltfAcc>(rank % alpaka::pltf::getDevCount<PltfAcc>()));
+		DevHost devHost (alpaka::pltf::getDevByIdx<PltfHost>(0u));
 		Stream  stream  (devAcc);
 
 		const alpaka::Vec<SimDim, size_t> global_size(d[0]*VOLUME_X,d[1]*VOLUME_Y,d[2]*VOLUME_Z);

--- a/lib/ISAACConfig.cmake
+++ b/lib/ISAACConfig.cmake
@@ -64,6 +64,8 @@ if (ISAAC_JPEG)
         endif()
 endif (ISAAC_JPEG)
 
+set(ISAAC_VECTOR_ELEM "2" CACHE STRING "The amounts of elements used for vectorization. On GPU 1..2 should be fine, on CPU 4..16" )
+add_definitions(-DISAAC_VECTOR_ELEM=${ISAAC_VECTOR_ELEM})
 
 ###############################################################################
 # JANSSON LIB

--- a/lib/isaac.hpp
+++ b/lib/isaac.hpp
@@ -353,8 +353,8 @@ class IsaacVisualization
                     );
                     alpaka::stream::enqueue(stream, instance);
                     alpaka::wait::wait(stream);
-                    alpaka::mem::buf::BufPlainPtrWrapper<THost, minmax_struct, TFraDim, size_t> minmax_buffer(local_minmax_array_h, host, size_t(local_size_array.x * local_size_array.y));
-                    alpaka::mem::view::copy( stream, minmax_buffer, local_minmax, size_t(local_size_array.x * local_size_array.y));
+                    alpaka::mem::view::ViewPlainPtr<THost, minmax_struct, TFraDim, size_t> minmax_buffer(local_minmax_array_h, host, alpaka::Vec<TFraDim, size_t>::Vec(size_t(local_size_array.x * local_size_array.y)));
+                    alpaka::mem::view::copy( stream, minmax_buffer, local_minmax, alpaka::Vec<TFraDim, size_t>::Vec(size_t(local_size_array.x * local_size_array.y)));
                 #else
                     dim3 block (block_size.x, block_size.y);
                     dim3 grid  (grid_size.x, grid_size.y);
@@ -771,8 +771,8 @@ class IsaacVisualization
             dest_array_struct< boost::mpl::size< TSourceList >::type::value > dest;
             isaac_for_each_params( sources, update_functor_chain_iterator(), functions, dest);
             #if ISAAC_ALPAKA == 1
-                alpaka::mem::buf::BufPlainPtrWrapper<THost, isaac_float4, TFraDim, size_t> parameter_buffer(isaac_parameter_h, host, size_t(ISAAC_MAX_FUNCTORS * boost::mpl::size< TSourceList >::type::value));
-                alpaka::mem::view::copy( stream, parameter_d, parameter_buffer, size_t(ISAAC_MAX_FUNCTORS * boost::mpl::size< TSourceList >::type::value));
+                alpaka::mem::view::ViewPlainPtr<THost, isaac_float4, TFraDim, size_t> parameter_buffer(isaac_parameter_h, host, alpaka::Vec<TFraDim, size_t>::Vec(size_t(ISAAC_MAX_FUNCTORS * boost::mpl::size< TSourceList >::type::value)));
+                alpaka::mem::view::copy( stream, parameter_d, parameter_buffer, alpaka::Vec<TFraDim, size_t>(size_t(ISAAC_MAX_FUNCTORS * boost::mpl::size< TSourceList >::type::value)));
                 const alpaka::Vec<TAccDim, size_t> threads (size_t(1), size_t(1), size_t(1));
                 const alpaka::Vec<TAccDim, size_t> blocks  (size_t(1), size_t(1), size_t(1));
                 const alpaka::Vec<TAccDim, size_t> grid    (size_t(1), size_t(1), size_t(1));
@@ -1491,8 +1491,8 @@ class IsaacVisualization
                 alpaka::wait::wait(myself->stream);
                 ISAAC_STOP_TIME_MEASUREMENT( myself->kernel_time, +=, kernel, myself->getTicksUs() )
                 ISAAC_START_TIME_MEASUREMENT( copy, myself->getTicksUs() )
-                alpaka::mem::buf::BufPlainPtrWrapper<THost, uint32_t, TFraDim, size_t> result_buffer((uint32_t*)(pixels), myself->host, myself->framebuffer_prod);
-                alpaka::mem::view::copy(myself->stream, result_buffer, myself->framebuffer, myself->framebuffer_prod);
+                alpaka::mem::view::ViewPlainPtr<THost, uint32_t, TFraDim, size_t> result_buffer((uint32_t*)(pixels), myself->host, alpaka::Vec<TFraDim, size_t>::Vec(myself->framebuffer_prod));
+                alpaka::mem::view::copy(myself->stream, result_buffer, myself->framebuffer, alpaka::Vec<TFraDim, size_t>::Vec(myself->framebuffer_prod));
             #else
                 IsaacFillRectKernelStruct
                 <

--- a/lib/isaac/isaac_defines.hpp
+++ b/lib/isaac/isaac_defines.hpp
@@ -54,19 +54,23 @@
 #define ISAAC_Z_FAR 100.0f
 
 #if ISAAC_ALPAKA == 1
-    #define ISAAC_HOST_DEVICE_INLINE ALPAKA_FN_ACC
+    #if __CUDACC__
+        #define ISAAC_HOST_DEVICE_INLINE ALPAKA_FN_ACC __forceinline__
+    #else
+        #define ISAAC_HOST_DEVICE_INLINE ALPAKA_FN_ACC inline
+    #endif
 #else
     #define ISAAC_HOST_DEVICE_INLINE __device__ __host__ __forceinline__
 #endif
 
 #if ISAAC_ALPAKA == 1
-    #define ISAAC_HOST_INLINE ALPAKA_FN_HOST
+    #define ISAAC_HOST_INLINE ALPAKA_FN_HOST inline
 #else
     #define ISAAC_HOST_INLINE __host__ __forceinline__
 #endif
 
 #if ISAAC_ALPAKA == 1
-    #define ISAAC_DEVICE_INLINE ALPAKA_FN_ACC_CUDA_ONLY
+    #define ISAAC_DEVICE_INLINE ISAAC_HOST_DEVICE_INLINE
 #else
     #define ISAAC_DEVICE_INLINE __device__ __forceinline__
 #endif

--- a/lib/isaac/isaac_defines.hpp
+++ b/lib/isaac/isaac_defines.hpp
@@ -17,6 +17,10 @@
 
 #include <boost/preprocessor.hpp>
 
+#ifndef ISAAC_VECTOR_ELEM
+    #define ISAAC_VECTOR_ELEM 2
+#endif
+
 #ifndef ISAAC_MAX_DIFFERENCE
     #define ISAAC_MAX_DIFFERENCE 4
 #endif
@@ -78,3 +82,15 @@
 #else
     #define ISAAC_NO_HOST_DEVICE_WARNING
 #endif
+
+#define ISAAC_ELEM_ITERATE( NAME ) for (isaac_uint NAME = 0; NAME < isaac_uint(ISAAC_VECTOR_ELEM); NAME++)
+
+#define ISAAC_ELEM_ALL_TRUE_RETURN( NAME ) \
+{ \
+    bool all_true = true; \
+    for (isaac_uint e = 0; e < isaac_uint(ISAAC_VECTOR_ELEM); e++) \
+        if (NAME[e] == false) \
+            all_true = false; \
+    if (all_true) \
+        return; \
+}

--- a/lib/isaac/isaac_defines.hpp
+++ b/lib/isaac/isaac_defines.hpp
@@ -94,3 +94,9 @@
     if (all_true) \
         return; \
 }
+
+#if ISAAC_ALPAKA == 1
+    #define ISAAC_CONSTANT ALPAKA_STATIC_DEV_MEM_CONSTANT
+#else
+    #define ISAAC_CONSTANT __constant__
+#endif

--- a/lib/isaac/isaac_types.hpp
+++ b/lib/isaac/isaac_types.hpp
@@ -96,7 +96,7 @@ BOOST_PP_REPEAT(4, ISAAC_SIZE_DEF, ~)
     result. BOOST_PP_ARRAY_ELEM( I, BOOST_PP_SEQ_TO_ARRAY( ISAAC_COMPONENTS_SEQ_3 ) ) = BOOST_PP_ARRAY_ELEM( 1, OP ) \
     left. BOOST_PP_ARRAY_ELEM( I, BOOST_PP_SEQ_TO_ARRAY( ISAAC_COMPONENTS_SEQ_3 ) );
 
-//macro for the any operator for isaac_{type}[2,3,4]. 
+//macro for the any operator for isaac_{type}[2,3,4].
 #define ISAAC_OVERLOAD_OPERATOR_DEF(Z, I, OP) \
     ISAAC_HOST_DEVICE_INLINE BOOST_PP_CAT( BOOST_PP_CAT( isaac_ , BOOST_PP_ARRAY_ELEM( 0, OP ) ), BOOST_PP_INC(I) ) operator BOOST_PP_ARRAY_ELEM( 1, OP ) ( \
     const BOOST_PP_CAT( BOOST_PP_CAT( isaac_ , BOOST_PP_ARRAY_ELEM( 0, OP ) ), BOOST_PP_INC(I) ) & left, \
@@ -166,7 +166,7 @@ ISAAC_OVERLOAD_OPERATOR_CREATE(size)
     struct BOOST_PP_CAT( isaac_, BOOST_PP_ARRAY_ELEM( I, ISAAC_DIM_TYPES_DIM ) ) \
     < size_t( BOOST_PP_INC(J) ) > { \
     BOOST_PP_CAT( isaac_, BOOST_PP_CAT( BOOST_PP_ARRAY_ELEM( I, ISAAC_DIM_TYPES ) , BOOST_PP_INC(J) ) ) value; };
-    
+
 #define ISAAC_DIM_DEF(Z, I, unused) \
     template < size_t > \
     struct BOOST_PP_CAT( isaac_ , BOOST_PP_ARRAY_ELEM( I, ISAAC_DIM_TYPES_DIM ) ); \
@@ -240,7 +240,7 @@ struct minmax_array_struct
 
 struct clipping_struct
 {
-    inline clipping_struct() :
+    ISAAC_HOST_DEVICE_INLINE clipping_struct() :
         count(0)
     {}
     isaac_uint count;


### PR DESCRIPTION
This commits add support for the most recent alpaka version, but also uses more optimizations like inlining and some basic vectorization attempts.
This gives a speedup of ~30-40% for OpenMP at first tests.
Furthermore as Alpaka does now support CUDA Constant Memory the cuda and alpaka-cuda version now use the same code and it seems, that alpaka is even a bit faster than native CUDA.