### PR TITLE
Use boolean definition from libjpeg headers.

### DIFF
--- a/server/src/Broker.cpp
+++ b/server/src/Broker.cpp
@@ -108,14 +108,14 @@ MetaDataClient* Broker::addDataClient()
 	}
 	boolean isaac_jpeg_fill_input_buffer(j_decompress_ptr cinfo)
 	{
-		return true;
+		return TRUE;
 	}
 	void isaac_jpeg_skip_input_data(j_decompress_ptr cinfo,long num_bytes)
 	{
 	}
 	boolean isaac_jpeg_resync_to_restart(j_decompress_ptr cinfo, int desired)
 	{
-		return true;
+		return TRUE;
 	}
 	void isaac_jpeg_term_source(j_decompress_ptr cinfo)
 	{

--- a/server/src/URIImageConnector.cpp
+++ b/server/src/URIImageConnector.cpp
@@ -40,7 +40,7 @@ void isaac_init_destination(j_compress_ptr cinfo)
 }
 boolean isaac_jpeg_empty_output_buffer(j_compress_ptr cinfo)
 {
-	return true;
+	return TRUE;
 }
 void isaac_jpeg_term_destination(j_compress_ptr cinfo)
 {


### PR DESCRIPTION
'boolean' type is defined in jmorecfg.h of libjpeg library. For example, in libjpeg-9b it is defined as
```C
typedef enum { FALSE = 0, TRUE = 1 } boolean;
```
which makes 'true' an invalid return type.