### PR TITLE
CMake: Honor _ROOT Env Hints

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required (VERSION 3.3)
 project (example)
 
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 11)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required (VERSION 3.3)
 project (isaac)
 
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 configure_file (
 	"${PROJECT_SOURCE_DIR}/ISAACConfigVersion.cmake.in"
 	"${PROJECT_BINARY_DIR}/ISAACConfigVersion.cmake"

--- a/lib/ISAACConfig.cmake
+++ b/lib/ISAACConfig.cmake
@@ -17,7 +17,22 @@
 # ISAAC
 ###############################################################################
 cmake_minimum_required (VERSION 3.3.0)
-cmake_policy(SET CMP0048 OLD)
+
+
+################################################################################
+# CMake Policies
+###############################################################################
+# TODO update our VERSION syntax in project
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0048.html
+if(POLICY CMP0048)
+    cmake_policy(SET CMP0048 OLD)
+endif()
+
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/ISAACBaseDir.cmake")
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required (VERSION 3.3)
 project (isaac)
 
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(SRCS
 	${CMAKE_SOURCE_DIR}/src/isaac.cpp
 	${CMAKE_SOURCE_DIR}/src/Common.cpp


### PR DESCRIPTION
CMake 3.12.0+ honor `<Package>_ROOT` environment hints which are often set on HPC systems. Previously, it was only looking for `<Package>_DIR` paths in `find_package` calls.

This new policy is useful since HPC systems usually set `_DIR`, `_ROOT` or expand the `CMAKE_PREFIX_PATH`. Therefore we want to use it as soon as it is available.

On systems where those env vars are set, e.g. Hypnos, this also throws a warning if the default (OLD) policy is used with CMake 3.12.4 or newer.

References:

- https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
- https://github.com/ComputationalRadiationPhysics/picongpu/pull/2891