### PR TITLE
Use correct MIN/MAX functions in kernel

### DIFF
--- a/lib/isaac/isaac_kernel.hpp
+++ b/lib/isaac/isaac_kernel.hpp
@@ -2275,8 +2275,8 @@ namespace isaac
             for(int i = -3; i <= 3; i++) {
                 for(int j = -3; j <= 3; j++) {
                     //avoid out of bounds by simple min max
-                    isaac_int x = MAX(MIN(pixel.x + i * radius, framebuffer_start.x + framebuffer_size.x), framebuffer_start.x);
-                    isaac_int y = MAX(MIN(pixel.y + j * radius, framebuffer_start.y + framebuffer_size.y), framebuffer_start.y);
+                    isaac_int x = ISAAC_MAX(ISAAC_MIN(pixel.x + i * radius, framebuffer_start.x + framebuffer_size.x), framebuffer_start.x);
+                    isaac_int y = ISAAC_MAX(ISAAC_MIN(pixel.y + j * radius, framebuffer_start.y + framebuffer_size.y), framebuffer_start.y);
 
                     //get the neighbour depth value
                     isaac_float depth_sample = gDepth[x + y * framebuffer_size.x].z;


### PR DESCRIPTION
The use of MIN/MAX in the kernel resulted in compile errors in the kernel for the nvcc compiled example.

ISAAC_MIN/ISAAC_MAX are already used elsewhere in the kernel.