### PR TITLE
Fix for wrong depth values on clipping plane for ambient occlusion calculations

### DIFF
--- a/lib/isaac/isaac_kernel.hpp
+++ b/lib/isaac/isaac_kernel.hpp
@@ -757,6 +757,7 @@ namespace isaac
                             normal = start + t0 * dir - particle_pos;
                             if( t0 < 0 && is_clipped )
                             {
+                                color.w = 0;
                                 normal = -clipping_normal;
                             }
                         }


### PR DESCRIPTION
Before:
![canvas](https://user-images.githubusercontent.com/22729279/92696413-201b2200-f34a-11ea-92fb-028df03e44ab.png)
With fix:
![fixed](https://user-images.githubusercontent.com/22729279/92696426-23aea900-f34a-11ea-99b5-663550a025f1.png)
