### PR TITLE
Send/Receive buffer sizes adjustable in cmake as ISAAC_MAX_RECEIVE + added warnings/errors on overflow

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -78,6 +78,12 @@ if (ISAAC_GST)
 	add_definitions(-DISAAC_GST)
 endif (ISAAC_GST)
 
+
+
+set(ISAAC_MAX_RECEIVE "8388608" CACHE STRING "The size of the reserved buffers for sending and receiving, default of 8 MB should work for up to 4K" )
+set(ISAAC_DEFINITIONS ${ISAAC_DEFINITIONS} -DISAAC_MAX_RECEIVE=${ISAAC_MAX_RECEIVE})
+add_definitions(${ISAAC_DEFINITIONS})
+
 option(ISAAC_JPEG "Use JPEG compression between visualization and isaac server. Deactivating will not work with big images. And with big I am talking about bigger than 800x600." ON)
 if (ISAAC_JPEG)
 	find_package(JPEG REQUIRED)

--- a/server/src/Common.hpp
+++ b/server/src/Common.hpp
@@ -25,8 +25,6 @@ typedef int ClientRef;
 typedef int ObserverRef;
 typedef int errorCode;
 
-#define ISAAC_MAX_RECEIVE 4194304 //4 MB
-
 typedef enum
 {
 	FORCE_EXIT = -1,

--- a/server/src/InsituConnectorMaster.cpp
+++ b/server/src/InsituConnectorMaster.cpp
@@ -124,7 +124,15 @@ errorCode InsituConnectorMaster::run()
 					{
 						int add = recv(fd_array[i].fd,&(con_array[i]->connector->jlcb.buffer[con_array[i]->connector->jlcb.count]),4096,MSG_DONTWAIT);
 						if (add > 0)
+						{
 							con_array[i]->connector->jlcb.count += add;
+							if(con_array[i]->connector->jlcb.count > ISAAC_MAX_RECEIVE)
+							{
+								fprintf(stderr,"Fatal error: Socket received %d bytes but buffer is only %d bytes! To increase the allowed size set ISAAC_MAX_RECEIVE to a higher value.\n", 
+										con_array[i]->connector->jlcb.count, ISAAC_MAX_RECEIVE);
+								return -1;
+							}
+						}
 						else
 							break;
 					}


### PR DESCRIPTION
- LWS needs the information of the maximum buffer size for one package, otherwise larger messages are split, which would have major performance implications
