### PR TITLE
fix missing include

### DIFF
--- a/lib/isaac.hpp
+++ b/lib/isaac.hpp
@@ -22,7 +22,7 @@
 #define BOOST_RESULT_OF_USE_TR1
 #endif
 
-
+#include <iostream>
 #include <random>
 #include <string>
 #include <string.h>


### PR DESCRIPTION
`std:err` is used but `<iostream>` is not included.

The bug is in the library but broke the example. Since we mostly tested this code embedded in other applications, e.g. PIConGPU we used by accident the include from the application.