### PR TITLE
CMake: increase ISAAC compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,7 +165,7 @@ The ISAACConfig.cmake searches for these requirements. See
 *__glm__ for the internal math types and functions
   * _Debian/Ubuntu_:
     * `sudo apt-get install libglm-dev`
-  * _From Source_ (at least version 0.9.9.8 for updated cmake interface required, 
+  * _From Source_ (at least version 0.9.9 for updated cmake interface required, 
     older versions might also work, if `glmConfig.cmake` can be located):
     * `git clone git@github.com:g-truc/glm.git`
       * As glm is a header only library no installation is needed. Later while 

--- a/lib/ISAACConfig.cmake
+++ b/lib/ISAACConfig.cmake
@@ -153,20 +153,30 @@ set(ISAAC_PRIVATE_FOUND true)
 ################################################################################
 # Alpaka LIB
 ################################################################################
-find_package(alpaka QUIET)
-if (NOT alpaka_FOUND)
-    set(ISAAC_PRIVATE_FOUND false)
-    set(ISAAC_DEPENDENCY_HINTS ${ISAAC_DEPENDENCY_HINTS} "\n--   Alpaka")
+
+# alpaka target is already provided by another project
+if(NOT TARGET alpaka::alpaka)
+    set(isaac_MIN_ALPAKA_VERSION 0.6.0)
+    find_package(alpaka ${isaac_MIN_ALPAKA_VERSION})
+    if (NOT alpaka_FOUND)
+        set(ISAAC_PRIVATE_FOUND false)
+        set(ISAAC_DEPENDENCY_HINTS ${ISAAC_DEPENDENCY_HINTS} "\n--   Alpaka")
+    endif()
 endif()
+
 set(ISAAC_LIBRARIES ${ISAAC_LIBRARIES} "alpaka::alpaka")
 
 
 ################################################################################
 # GLM LIB
 ################################################################################
-find_package(glm REQUIRED)
-set(ISAAC_LIBRARIES ${ISAAC_LIBRARIES} "glm::glm")
-
+find_package(glm 0.9.9 REQUIRED)
+set(glm_TARGET_NAME "glm::glm")
+if(glm_VERSION VERSION_LESS 0.9.9.8)
+    # older glm version do not shipped the target glm::glm
+    set(glm_TARGET_NAME "glm")
+endif()
+set(ISAAC_LIBRARIES ${ISAAC_LIBRARIES} ${glm_TARGET_NAME})
 
 
 ################################################################################


### PR DESCRIPTION
- add support for glm 0.9.9 instead of 0.9.9.8+
- add support to integrate ISAAC in an app which provides alpaka as sub-directory
- enforce minimal alpaka version if cmake `find_package` is used

This PR is required to run ISAAC with PIConGPU without issue because of the alpaka version provided as sub-directoy.