### PR TITLE
Restores the step size scaling in ray direction

### DIFF
--- a/lib/isaac/isaac_iso_kernel.hpp
+++ b/lib/isaac/isaac_iso_kernel.hpp
@@ -413,9 +413,10 @@ namespace isaac
             isaac_float min_size = ISAAC_MIN(
                 int(SimulationSize.globalSize.x),
                 ISAAC_MIN(int(SimulationSize.globalSize.y), int(SimulationSize.globalSize.z)));
-            isaac_int startSteps = glm::ceil(ray.startDepth / stepSize);
-            isaac_int endSteps = glm::floor(ray.endDepth / stepSize);
-            isaac_float3 stepVec = stepSize * ray.dir / scale;
+            isaac_float stepSizeUnscaled = stepSize * (glm::length(ray.dir) / glm::length(ray.dir / scale));
+            isaac_int startSteps = glm::ceil(ray.startDepth / stepSizeUnscaled);
+            isaac_int endSteps = glm::floor(ray.endDepth / stepSizeUnscaled);
+            isaac_float3 stepVec = stepSizeUnscaled * ray.dir / scale;
             // unscale all data for correct memory access
             isaac_float3 startUnscaled = ray.start / scale;
 
@@ -446,14 +447,14 @@ namespace isaac
             {
                 pos = startUnscaled + stepVec * isaac_float(i);
                 bool first = ray.isClipped && i == startSteps;
-                isaac_float t = i * stepSize;
+                isaac_float t = i * stepSizeUnscaled;
                 forEachWithMplParams(
                     sources,
                     IsoStepSourceIterator<T_transferSize, T_Filter, T_interpolation>(),
                     ray,
                     t,
                     pos,
-                    stepSize,
+                    stepSizeUnscaled,
                     SimulationSize.localSize,
                     transferArray,
                     sourceIsoThreshold,

--- a/lib/isaac/isaac_volume_kernel.hpp
+++ b/lib/isaac/isaac_volume_kernel.hpp
@@ -209,13 +209,14 @@ namespace isaac
             isaac_float min_size = ISAAC_MIN(
                 int(SimulationSize.globalSize.x),
                 ISAAC_MIN(int(SimulationSize.globalSize.y), int(SimulationSize.globalSize.z)));
-            isaac_float factor = stepSize / min_size * 2.0f;
+            isaac_float stepSizeUnscaled = stepSize * (glm::length(ray.dir) / glm::length(ray.dir / scale));
+            isaac_float factor = stepSizeUnscaled / min_size * 2.0f;
             isaac_float4 value = isaac_float4(0);
             isaac_float oma;
             isaac_float4 colorAdd;
-            isaac_int startSteps = glm::ceil(ray.startDepth / stepSize);
-            isaac_int endSteps = glm::floor(ray.endDepth / stepSize);
-            isaac_float3 stepVec = stepSize * ray.dir / scale;
+            isaac_int startSteps = glm::ceil(ray.startDepth / stepSizeUnscaled);
+            isaac_int endSteps = glm::floor(ray.endDepth / stepSizeUnscaled);
+            isaac_float3 stepVec = stepSizeUnscaled * ray.dir / scale;
             // unscale all data for correct memory access
             isaac_float3 startUnscaled = ray.start / scale;
 


### PR DESCRIPTION
With the rework, the step size was defined in the scaled global space and has a uniform step size throughout the volume regardless of scaling.

Before the rework, however, it was defined in the unscaled space and was scaled like the volume, which resulted in fewer steps in the scaled direction for scaling `>1`.

This PR reintroduces this behavior to keep performance comparable to previous versions.
