### PR TITLE
Prevent compiler error if no source is provided and arrays get initialized with 0

### DIFF
--- a/lib/isaac/isaac_functor_chain.hpp
+++ b/lib/isaac/isaac_functor_chain.hpp
@@ -46,7 +46,7 @@ namespace isaac
     template<int T_n>
     struct DestArrayStruct
     {
-        isaac_int nr[T_n];
+        isaac_int nr[ZeroCheck<T_n>::value];
     };
 
     ISAAC_DEVICE_INLINE isaac_float applyFunctorChain(isaac_float_dim<1>& data, const int nr)

--- a/lib/isaac/isaac_iso_kernel.hpp
+++ b/lib/isaac/isaac_iso_kernel.hpp
@@ -439,7 +439,7 @@ namespace isaac
             isaac_float depth = ray.endDepth;
             isaac_float4 hitColor = isaac_float4(0);
             isaac_float3 hitNormal;
-            isaac_float oldValues[boost::mpl::size<T_SourceList>::type::value];
+            isaac_float oldValues[ZeroCheck<boost::mpl::size<T_SourceList>::type::value>::value];
             for(int i = 0; i < boost::mpl::size<T_SourceList>::type::value; i++)
                 oldValues[i] = 0;
             // iterate over the volume

--- a/lib/isaac/isaac_types.hpp
+++ b/lib/isaac/isaac_types.hpp
@@ -95,7 +95,7 @@ namespace isaac
     {
         isaac_size3 globalSize; // size of volume
         ISAAC_IDX_TYPE
-            maxGlobalSize; // each dimension has a size and this value contains the value of the greatest dimension
+        maxGlobalSize; // each dimension has a size and this value contains the value of the greatest dimension
         isaac_size3 position; // local position of subvolume
         isaac_size3 localSize; // size of local volume grid
         isaac_size3 localParticleSize; // size of local particle grid
@@ -116,16 +116,28 @@ namespace isaac
     };
 
     template<int T_n>
+    struct ZeroCheck
+    {
+        static const int value = T_n;
+    };
+
+    template<>
+    struct ZeroCheck<0>
+    {
+        static const int value = 1;
+    };
+
+    template<int T_n>
     struct TransferDeviceStruct
     {
-        isaac_float4* pointer[T_n];
+        isaac_float4* pointer[ZeroCheck<T_n>::value];
     };
 
     template<int T_n>
     struct TransferHostStruct
     {
-        isaac_float4* pointer[T_n];
-        std::map<isaac_uint, isaac_float4> description[T_n];
+        isaac_float4* pointer[ZeroCheck<T_n>::value];
+        std::map<isaac_uint, isaac_float4> description[ZeroCheck<T_n>::value];
     };
 
     struct FunctionsStruct
@@ -138,19 +150,19 @@ namespace isaac
     template<int T_n>
     struct IsoThresholdStruct
     {
-        isaac_float value[T_n];
+        isaac_float value[ZeroCheck<T_n>::value];
     };
 
     template<int T_n>
     struct SourceWeightStruct
     {
-        isaac_float value[T_n];
+        isaac_float value[ZeroCheck<T_n>::value];
     };
 
     template<int T_n>
     struct PointerArrayStruct
     {
-        void* pointer[T_n];
+        void* pointer[ZeroCheck<T_n>::value];
     };
 
     struct MinMax
@@ -162,8 +174,8 @@ namespace isaac
     template<int T_n>
     struct MinMaxArray
     {
-        isaac_float min[T_n];
-        isaac_float max[T_n];
+        isaac_float min[ZeroCheck<T_n>::value];
+        isaac_float max[ZeroCheck<T_n>::value];
     };
 
     struct ClippingStruct


### PR DESCRIPTION
- This hotfix prevents 0 initialization of arrays depending on the source list size by initializing them with 1 instead

Should fix #137 