### PR TITLE
Update IceT repository.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,8 +121,8 @@ The ISAACConfig.cmake searches for these requirements. See
   * _Debian/Ubuntu_ (as part of Paraview):
     * `sudo apt-get install paraview-dev`
   * _From Source_:
-    * `git clone git://public.kitware.com/IceT.git`
-    * `cd IceT`
+    * `git clone https://gitlab.kitware.com/icet/icet.git`
+    * `cd icet`
     * `mkdir build`
     * With admin rights and no other version of IceT installed:
       * `cd build`


### PR DESCRIPTION
The `public.kitware....` repository was not functional and
is replaced with the GitLab repository.