### PR TITLE
Fix for moving window by allowing negative position and clipping to the global volume

### DIFF
--- a/lib/isaac.hpp
+++ b/lib/isaac.hpp
@@ -574,7 +574,7 @@ namespace isaac
             const isaac_size3 globalSize,
             const isaac_size3 localSize,
             const isaac_size3 localParticleSize,
-            const isaac_size3 position,
+            const isaac_int3 position,
             T_VolumeSourceList& volumeSources,
             T_FieldSourceList& fieldSources,
             T_ParticleList& particleSources,
@@ -1053,7 +1053,7 @@ namespace isaac
         }
 
 
-        void updatePosition(const isaac_size3 position)
+        void updatePosition(const isaac_int3 position)
         {
             ISAAC_WAIT_VISUALIZATION
             this->position = position;
@@ -2932,10 +2932,10 @@ namespace isaac
         isaac_size3 globalSize;
         isaac_size3 localSize;
         isaac_size3 localParticleSize;
-        isaac_size3 position;
+        isaac_int3 position;
         isaac_size3 globalSizeScaled;
         isaac_size3 localSizeScaled;
-        isaac_size3 positionScaled;
+        isaac_int3 positionScaled;
         MPI_Comm mpiWorld;
         std::vector<isaac_dmat4> projections;
         isaac_dmat4 modelview; // modelview matrix

--- a/lib/isaac/isaac_common_kernel.hpp
+++ b/lib/isaac/isaac_common_kernel.hpp
@@ -120,8 +120,12 @@ namespace isaac
         }
 
         // clip ray on volume bounding box
-        isaac_float3 bbIntersectionMin = -ray.start / ray.dir;
-        isaac_float3 bbIntersectionMax = (isaac_float3(SimulationSize.localSizeScaled) - ray.start) / ray.dir;
+        isaac_int3 bbMinLocal = glm::max(isaac_int3(0), -SimulationSize.positionScaled);
+        isaac_int3 bbMaxLocal = glm::min(
+            isaac_int3(SimulationSize.localSizeScaled),
+            isaac_int3(SimulationSize.globalSizeScaled) - SimulationSize.positionScaled);
+        isaac_float3 bbIntersectionMin = (isaac_float3(bbMinLocal) - ray.start) / ray.dir;
+        isaac_float3 bbIntersectionMax = (isaac_float3(bbMaxLocal) - ray.start) / ray.dir;
 
         // bbIntersectionMin shall have the smaller values
         swapIfSmaller(bbIntersectionMax.x, bbIntersectionMin.x);

--- a/lib/isaac/isaac_types.hpp
+++ b/lib/isaac/isaac_types.hpp
@@ -121,12 +121,12 @@ namespace isaac
         isaac_size3 globalSize; // size of volume
         ISAAC_IDX_TYPE
         maxGlobalSize; // each dimension has a size and this value contains the value of the greatest dimension
-        isaac_size3 position; // local position of subvolume
+        isaac_int3 position; // local position of subvolume
         isaac_size3 localSize; // size of local volume grid
         isaac_size3 localParticleSize; // size of local particle grid
         isaac_size3 globalSizeScaled; // scaled version of global size with cells = scale * cells
         ISAAC_IDX_TYPE maxGlobalSizeScaled; // same as globalSizeScaled
-        isaac_size3 positionScaled; // scaled position of local subvolume
+        isaac_int3 positionScaled; // scaled position of local subvolume
         isaac_size3 localSizeScaled; // same as globalSizeScaled
     };
 


### PR DESCRIPTION
Fixes moving window issues https://github.com/ComputationalRadiationPhysics/isaac/issues/146#issue-968862927 and https://github.com/ComputationalRadiationPhysics/isaac/issues/145#issue-968860368

The changes are compatible with PIConGPU after https://github.com/ComputationalRadiationPhysics/picongpu/pull/3719#issue-710602438, but will only take effect after the related PR of the `IsaacPlugin.hpp` https://github.com/ComputationalRadiationPhysics/picongpu/pull/3733#issue-976838603 is merged.