### PR TITLE
Fix of the 'sum' function.

### DIFF
--- a/lib/isaac/isaac_functors.hpp
+++ b/lib/isaac/isaac_functors.hpp
@@ -163,7 +163,7 @@ namespace isaac
         template<int N>
         ISAAC_HOST_DEVICE_INLINE static isaac_float_dim<1> call(const isaac_float_dim<N> v, const isaac_float4& p)
         {
-            isaac_float_dim<1> result;
+            isaac_float_dim<1> result(0.0);
 
             for(int i = 0; i < N; ++i)
             {


### PR DESCRIPTION
Fix of  #153 .

The error was due to a definition of `result` in the summation functor without initialization. `isaac_float_dim<1>`, resp. `glm` does not appear to _initialize_ the storage. With these changes I obtain a proper output for the ranges and the function seems to be working properly:

![summationFix](https://user-images.githubusercontent.com/50339174/169086096-7ee4a5a4-a24a-4001-b22e-6d2d903570a5.jpeg)
