### PR TITLE
fix documentation: alpaka requirements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ be built yourself nevertheless or the distribution versions are outdated.
 The ISAACConfig.cmake searches for these requirements. See
 `example/CMakeLists.txt` for an easy to adopt example.
 
-* __alpaka__ (version 0.6.0) for the abstraction of the acceleration device. If only CUDA
+* __alpaka__ (version 0.9.0) for the abstraction of the acceleration device. If only CUDA
   is used, this library is __not needed__:
   * _From Source_:
     * `git clone https://github.com/alpaka-group/alpaka.git`


### PR DESCRIPTION
Increase the required version of alpaka to 0.9.0.

There is a high chance that alpaka 0.6.0+ is working with ISAAC but since we only test e.g. with PIConGPU alpaka 0.9.0 we should not recommend using older versions of alpaka than 0.9.0.