### PR TITLE
fix value underflow

### DIFF
--- a/lib/isaac/isaac_common_kernel.hpp
+++ b/lib/isaac/isaac_common_kernel.hpp
@@ -587,9 +587,11 @@ namespace isaac
                     texValue = persistentTextureArray.textures[T_NR::value][coord];
                 }
                 // apply transfer function
-                ISAAC_IDX_TYPE lookupValue = ISAAC_IDX_TYPE(glm::round(texValue * isaac_float(T_transferSize)));
-                lookupValue = glm::clamp(lookupValue, ISAAC_IDX_TYPE(0), T_transferSize - 1);
-                const isaac_float4 color = transferArray.pointer[T_NR::value][lookupValue];
+                isaac_float lookupValue = glm::round(texValue * isaac_float(T_transferSize));
+                ISAAC_IDX_TYPE lookupIdx
+                    = ISAAC_IDX_TYPE(glm::clamp(lookupValue, isaac_float(0), isaac_float(T_transferSize - 1)));
+
+                const isaac_float4 color = transferArray.pointer[T_NR::value][lookupIdx];
                 if(volumeWeight > 0)
                 {
                     // create alpha weighted sum for volume visualization if activated
@@ -654,9 +656,11 @@ namespace isaac
                 // texValue *= advectionTextures.textures[T_NR::value][coord];
 
                 // apply transfer function
-                ISAAC_IDX_TYPE lookupValue = ISAAC_IDX_TYPE(glm::round(texValue * isaac_float(T_transferSize)));
-                lookupValue = glm::clamp(lookupValue, ISAAC_IDX_TYPE(0), T_transferSize - 1);
-                isaac_float4 color = transferArray.pointer[T_NR::value + T_Offset][lookupValue];
+                isaac_float lookupValue = glm::round(texValue * isaac_float(T_transferSize));
+                ISAAC_IDX_TYPE lookupIdx
+                    = ISAAC_IDX_TYPE(glm::clamp(lookupValue, isaac_float(0), isaac_float(T_transferSize - 1)));
+
+                isaac_float4 color = transferArray.pointer[T_NR::value + T_Offset][lookupIdx];
                 // blend alpha channel with advection texture value
                 color.a *= (advectionTextures.textures[T_NR::value][coord] / isaac_float(255));
                 if(volumeWeight > 0)

--- a/lib/isaac/isaac_iso_kernel.hpp
+++ b/lib/isaac/isaac_iso_kernel.hpp
@@ -270,9 +270,9 @@ namespace isaac
                 checkCoord<T_Source>(p1Unscaled, localSize);
                 isaac_float result1
                     = getValue<T_interpolation, T_NR::value>(source, p1Unscaled, persistentTextureArray, localSize);
-                ISAAC_IDX_TYPE lookupValue = ISAAC_IDX_TYPE(glm::round(result1 * isaac_float(T_transferSize)));
-                lookupValue = glm::clamp(lookupValue, ISAAC_IDX_TYPE(0), T_transferSize - 1);
-                isaac_float value1 = transferArray.pointer[T_NR::value][lookupValue].a;
+                isaac_float lookupValue = glm::round(result1 * isaac_float(T_transferSize));
+                ISAAC_IDX_TYPE lookupIdx = ISAAC_IDX_TYPE(glm::clamp(lookupValue, isaac_float(0),
+    isaac_float(T_transferSize - 1))); isaac_float value1 = transferArray.pointer[T_NR::value][lookupIdx].a;
                 oldValues[T_NR::value] = value1;
 
 
@@ -294,9 +294,9 @@ namespace isaac
                 // get color of hit
                 isaac_float result
                     = getValue<T_interpolation, T_NR::value>(source, posUnscaled, persistentTextureArray, localSize);
-                lookupValue = ISAAC_IDX_TYPE(glm::round(result * isaac_float(T_transferSize)));
-                lookupValue = glm::clamp(lookupValue, ISAAC_IDX_TYPE(0), T_transferSize - 1);
-                hitColor = transferArray.pointer[T_NR::value][lookupValue];
+                lookupValue = glm::round(result * isaac_float(T_transferSize));
+                lookupIdx = ISAAC_IDX_TYPE(glm::clamp(lookupValue, isaac_float(0), isaac_float(T_transferSize - 1)));
+                hitColor = transferArray.pointer[T_NR::value][lookupIdx];
                 hitColor.a = 1.0f;
                 isaac_float3 gradient = getGradient<T_interpolation, T_NR::value>(
                     source,

--- a/lib/isaac/isaac_particle_kernel.hpp
+++ b/lib/isaac/isaac_particle_kernel.hpp
@@ -84,10 +84,10 @@ namespace isaac
                             result = applyFunctorChain(data, sourceNumber);
 
                             // apply transferfunction
-                            ISAAC_IDX_TYPE lookupValue
-                                = ISAAC_IDX_TYPE(glm::round(result * isaac_float(T_transferSize)));
-                            lookupValue = glm::clamp(lookupValue, ISAAC_IDX_TYPE(0), T_transferSize - 1);
-                            isaac_float4 value = transferArray.pointer[sourceNumber][lookupValue];
+                            isaac_float lookupValue = glm::round(result * isaac_float(T_transferSize));
+                            ISAAC_IDX_TYPE lookupIdx = ISAAC_IDX_TYPE(
+                                glm::clamp(lookupValue, isaac_float(0), isaac_float(T_transferSize - 1)));
+                            isaac_float4 value = transferArray.pointer[sourceNumber][lookupIdx];
 
                             // check if the alpha value is greater or equal than 0.5
                             if(value.w >= 0.5f)
@@ -358,9 +358,8 @@ namespace isaac
                 T_transferSize,
                 T_sourceOffset>
                 kernel;
-            auto const instance =
-                alpaka::createTaskKernel<
-                    T_Acc>(workdiv, kernel, gBuffer, particleSources, transferArray, sourceWeight, scale, clipping);
+            auto const instance = alpaka::createTaskKernel<
+                T_Acc>(workdiv, kernel, gBuffer, particleSources, transferArray, sourceWeight, scale, clipping);
             alpaka::enqueue(stream, instance);
         }
     };

--- a/lib/isaac/isaac_volume_kernel.hpp
+++ b/lib/isaac/isaac_volume_kernel.hpp
@@ -161,9 +161,10 @@ namespace isaac
             result = sampler.sample(texture, pos);
         }
         // return isaac_float4(1, 0, 0, result);
-        ISAAC_IDX_TYPE lookupValue = ISAAC_IDX_TYPE(glm::round(result * isaac_float(T_transferSize)));
-        lookupValue = glm::clamp(lookupValue, ISAAC_IDX_TYPE(0), T_transferSize - 1);
-        return transferArray.pointer[T_nr + T_offset][lookupValue];
+        isaac_float lookupValue = glm::round(result * isaac_float(T_transferSize));
+        ISAAC_IDX_TYPE lookupIdx
+            = ISAAC_IDX_TYPE(glm::clamp(lookupValue, isaac_float(0), isaac_float(T_transferSize - 1)));
+        return transferArray.pointer[T_nr + T_offset][lookupIdx];
     }
 
     template<


### PR DESCRIPTION
In the default case, the ISAAC index type is unsigned. During the mapping from the value to the transfer function index type a value underflows and happened and therefore negative values get mapped to the max transfer function value. The result is artifacts during the visualization.

Fix this behavior by clamping with float values before we cast back to an index type.

@PrometheusPi Could you please check if this fix solves the visualization issues? I do not have a test chain ready.