### PR TITLE
fix IceT lookup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ The ISAACConfig.cmake searches for these requirements. See
       * Now a local version of IceT is installed in the install
         directory in the IceT root folder. Later while compiling
         an application using ISAAC (including the examples) add
-        `-DIceT_DIR=$ICET/install/lib`, where
+        `-DIceT_DIR=$ICET/install`, where
         `$ICET` is the root folder of IceT (the directory
         `git clone …` created).
 * __MPI__ for the communication on the cluster. This should be available on

--- a/lib/ISAACConfig.cmake
+++ b/lib/ISAACConfig.cmake
@@ -152,7 +152,8 @@ set(ISAAC_LIBRARIES ${ISAAC_LIBRARIES} Threads::Threads)
 ################################################################################
 # IceT LIB
 ################################################################################
-find_package (IceT CONFIG QUIET)
+# PATH_SUFFIXES is required because IceT is not following the CMake find_package folder structure
+find_package (IceT CONFIG QUIET PATH_SUFFIXES "/lib/")
 if (NOT IceT_FOUND)
     set(ISAAC_DEPENDENCY_HINTS ${ISAAC_DEPENDENCY_HINTS} "\n--   IceT")
 endif()


### PR DESCRIPTION
IceT is not found by CMakes find_package if `CMAKE_PREFIX_PATH` is set to the root folder of IceT.
By adding a search suffix this can be solved.