### PR TITLE
fix ISAAC server

### DIFF
--- a/server/src/Broker.cpp
+++ b/server/src/Broker.cpp
@@ -430,36 +430,40 @@ errorCode Broker::run()
                     if(insituContainer->group)
                     {
                         InsituConnectorGroup* group = insituContainer->group;
-                        // Add id of group
-                        json_object_set_new(message->json_root, "id", json_integer(group->getID()));
-                        ThreadList<MetaDataClient*>::ThreadListContainer_ptr dc = dataClientList.getFront();
-                        while(dc)
+                        if(group->master == insituContainer)
                         {
-                            dc->t->masterSendMessage(new MessageContainer(EXIT_PLUGIN, message->json_root, true));
-                            dc = dc->next;
-                        }
-                        for(auto it = imageConnectorList.begin(); it != imageConnectorList.end(); it++)
-                            (*it).second.connector->masterSendMessage(
-                                new ImageBufferContainer(GROUP_FINISHED, NULL, group, 1));
-                        // Now let's remove the whole group
-                        group->master->group = NULL;
-                        printf("Removed group %i\n", group->id);
-                        ThreadList<InsituConnectorGroup*>::ThreadListContainer_ptr it
-                            = insituConnectorGroupList.getFront();
-                        while(it)
-                        {
-                            if(it->t == group)
+                            // Add id of group
+                            json_object_set_new(message->json_root, "id", json_integer(group->getID()));
+                            ThreadList<MetaDataClient*>::ThreadListContainer_ptr dc = dataClientList.getFront();
+                            while(dc)
                             {
-                                pthread_t thread;
-                                pthread_create(
-                                    &thread,
-                                    NULL,
-                                    delete_pointer_later<InsituConnectorGroup>,
-                                    insituConnectorGroupList.remove(it));
-                                break;
+                                dc->t->masterSendMessage(new MessageContainer(EXIT_PLUGIN, message->json_root, true));
+                                dc = dc->next;
                             }
-                            it = it->next;
+                            for(auto it = imageConnectorList.begin(); it != imageConnectorList.end(); it++)
+                                (*it).second.connector->masterSendMessage(
+                                    new ImageBufferContainer(GROUP_FINISHED, NULL, group, 1));
+                            // Now let's remove the whole group
+                            group->master->group = NULL;
+                            printf("Removed group %i\n", group->id);
+                            ThreadList<InsituConnectorGroup*>::ThreadListContainer_ptr it
+                                = insituConnectorGroupList.getFront();
+                            while(it)
+                            {
+                                if(it->t == group)
+                                {
+                                    pthread_t thread;
+                                    pthread_create(
+                                        &thread,
+                                        NULL,
+                                        delete_pointer_later<InsituConnectorGroup>,
+                                        insituConnectorGroupList.remove(it));
+                                    break;
+                                }
+                                it = it->next;
+                            }
                         }
+                        insituContainer->group = NULL;
                     }
                     delete insituMaster.insituConnectorList.remove(insitu);
                     break;

--- a/server/src/InsituConnectorMaster.cpp
+++ b/server/src/InsituConnectorMaster.cpp
@@ -109,6 +109,7 @@ errorCode InsituConnectorMaster::run()
                         insituConnector->jlcb.count = 0;
                         InsituConnectorContainer* d = new InsituConnectorContainer();
                         d->connector = insituConnector;
+                        d->group = NULL;
                         con_array[fdnum] = d;
                         fd_array[fdnum].fd = newsockfd;
                         fd_array[fdnum].events = POLLIN;
@@ -119,6 +120,8 @@ errorCode InsituConnectorMaster::run()
             }
             for(int i = 1; i < fdnum; i++)
             {
+                bool closed = false;
+                const bool socket_closed = (fd_array[i].revents & (POLLHUP | POLLERR | POLLNVAL)) != 0;
                 if(fd_array[i].revents & POLLIN)
                 {
                     while(1)
@@ -147,7 +150,6 @@ errorCode InsituConnectorMaster::run()
                     }
                     con_array[i]->connector->jlcb.pos = 0;
                     con_array[i]->connector->jlcb.buffer[con_array[i]->connector->jlcb.count] = 0;
-                    bool closed = false;
                     if(con_array[i]->connector->jlcb.count > 0)
                     {
                         con_array[i]->connector->jlcb.buffer[con_array[i]->connector->jlcb.count] = 0;
@@ -238,17 +240,26 @@ errorCode InsituConnectorMaster::run()
                         con_array[i]->connector->clientSendMessage(message);
                         closed = true;
                     }
-                    if(closed)
+                }
+                if(socket_closed && !closed)
+                {
+                    MessageContainer* message = new MessageContainer(EXIT_PLUGIN, json_object());
+                    json_object_set_new(message->json_root, "type", json_string("exit"));
+                    con_array[i]->connector->clientSendMessage(message);
+                    closed = true;
+                }
+                if(closed)
+                {
+                    close(fd_array[i].fd);
+                    fdnum--;
+                    for(int j = i; j < fdnum; j++)
                     {
-                        close(fd_array[i].fd);
-                        fdnum--;
-                        for(int j = i; j < fdnum; j++)
-                        {
-                            fd_array[j] = fd_array[j + 1];
-                            con_array[j] = con_array[j + 1];
-                        }
-                        memset(&(fd_array[fdnum]), 0, sizeof(fd_array[fdnum]));
+                        fd_array[j] = fd_array[j + 1];
+                        con_array[j] = con_array[j + 1];
                     }
+                    memset(&(fd_array[fdnum]), 0, sizeof(fd_array[fdnum]));
+                    con_array[fdnum] = NULL;
+                    i--;
                 }
             }
         }


### PR DESCRIPTION
- InsituConnectorMaster::run() only processed POLLIN. - If a simulation socket closed with POLLHUP, POLLERR, or POLLNVAL, no EXIT_PLUGIN message was queued. - Result: the broker never removed the simulation from insituConnectorGroupList.

  - New InsituConnectorContainer objects did not initialize group.
  - A stale connector exit could remove a newer active group if group->master had been replaced by a same-name reconnect.

  Changes:

  - Convert POLLHUP/POLLERR/POLLNVAL into an EXIT_PLUGIN.
  - Initialize InsituConnectorContainer::group = NULL.
  - Only remove/broadcast a group exit if the exiting connector is still group->master.
  - Avoid skipping the next fd after compacting the poll arrays.


The AI scanned for server issues and found them.