### PR TITLE
Topic harden server

### DIFF
--- a/server/src/Broker.cpp
+++ b/server/src/Broker.cpp
@@ -430,36 +430,40 @@ errorCode Broker::run()
                     if(insituContainer->group)
                     {
                         InsituConnectorGroup* group = insituContainer->group;
-                        // Add id of group
-                        json_object_set_new(message->json_root, "id", json_integer(group->getID()));
-                        ThreadList<MetaDataClient*>::ThreadListContainer_ptr dc = dataClientList.getFront();
-                        while(dc)
+                        if(group->master == insituContainer)
                         {
-                            dc->t->masterSendMessage(new MessageContainer(EXIT_PLUGIN, message->json_root, true));
-                            dc = dc->next;
-                        }
-                        for(auto it = imageConnectorList.begin(); it != imageConnectorList.end(); it++)
-                            (*it).second.connector->masterSendMessage(
-                                new ImageBufferContainer(GROUP_FINISHED, NULL, group, 1));
-                        // Now let's remove the whole group
-                        group->master->group = NULL;
-                        printf("Removed group %i\n", group->id);
-                        ThreadList<InsituConnectorGroup*>::ThreadListContainer_ptr it
-                            = insituConnectorGroupList.getFront();
-                        while(it)
-                        {
-                            if(it->t == group)
+                            // Add id of group
+                            json_object_set_new(message->json_root, "id", json_integer(group->getID()));
+                            ThreadList<MetaDataClient*>::ThreadListContainer_ptr dc = dataClientList.getFront();
+                            while(dc)
                             {
-                                pthread_t thread;
-                                pthread_create(
-                                    &thread,
-                                    NULL,
-                                    delete_pointer_later<InsituConnectorGroup>,
-                                    insituConnectorGroupList.remove(it));
-                                break;
+                                dc->t->masterSendMessage(new MessageContainer(EXIT_PLUGIN, message->json_root, true));
+                                dc = dc->next;
                             }
-                            it = it->next;
+                            for(auto it = imageConnectorList.begin(); it != imageConnectorList.end(); it++)
+                                (*it).second.connector->masterSendMessage(
+                                    new ImageBufferContainer(GROUP_FINISHED, NULL, group, 1));
+                            // Now let's remove the whole group
+                            group->master->group = NULL;
+                            printf("Removed group %i\n", group->id);
+                            ThreadList<InsituConnectorGroup*>::ThreadListContainer_ptr it
+                                = insituConnectorGroupList.getFront();
+                            while(it)
+                            {
+                                if(it->t == group)
+                                {
+                                    pthread_t thread;
+                                    pthread_create(
+                                        &thread,
+                                        NULL,
+                                        delete_pointer_later<InsituConnectorGroup>,
+                                        insituConnectorGroupList.remove(it));
+                                    break;
+                                }
+                                it = it->next;
+                            }
                         }
+                        insituContainer->group = NULL;
                     }
                     delete insituMaster.insituConnectorList.remove(insitu);
                     break;

--- a/server/src/InsituConnectorMaster.cpp
+++ b/server/src/InsituConnectorMaster.cpp
@@ -109,6 +109,7 @@ errorCode InsituConnectorMaster::run()
                         insituConnector->jlcb.count = 0;
                         InsituConnectorContainer* d = new InsituConnectorContainer();
                         d->connector = insituConnector;
+                        d->group = NULL;
                         con_array[fdnum] = d;
                         fd_array[fdnum].fd = newsockfd;
                         fd_array[fdnum].events = POLLIN;
@@ -119,6 +120,8 @@ errorCode InsituConnectorMaster::run()
             }
             for(int i = 1; i < fdnum; i++)
             {
+                bool closed = false;
+                const bool socket_closed = (fd_array[i].revents & (POLLHUP | POLLERR | POLLNVAL)) != 0;
                 if(fd_array[i].revents & POLLIN)
                 {
                     while(1)
@@ -147,7 +150,6 @@ errorCode InsituConnectorMaster::run()
                     }
                     con_array[i]->connector->jlcb.pos = 0;
                     con_array[i]->connector->jlcb.buffer[con_array[i]->connector->jlcb.count] = 0;
-                    bool closed = false;
                     if(con_array[i]->connector->jlcb.count > 0)
                     {
                         con_array[i]->connector->jlcb.buffer[con_array[i]->connector->jlcb.count] = 0;
@@ -238,17 +240,26 @@ errorCode InsituConnectorMaster::run()
                         con_array[i]->connector->clientSendMessage(message);
                         closed = true;
                     }
-                    if(closed)
+                }
+                if(socket_closed && !closed)
+                {
+                    MessageContainer* message = new MessageContainer(EXIT_PLUGIN, json_object());
+                    json_object_set_new(message->json_root, "type", json_string("exit"));
+                    con_array[i]->connector->clientSendMessage(message);
+                    closed = true;
+                }
+                if(closed)
+                {
+                    close(fd_array[i].fd);
+                    fdnum--;
+                    for(int j = i; j < fdnum; j++)
                     {
-                        close(fd_array[i].fd);
-                        fdnum--;
-                        for(int j = i; j < fdnum; j++)
-                        {
-                            fd_array[j] = fd_array[j + 1];
-                            con_array[j] = con_array[j + 1];
-                        }
-                        memset(&(fd_array[fdnum]), 0, sizeof(fd_array[fdnum]));
+                        fd_array[j] = fd_array[j + 1];
+                        con_array[j] = con_array[j + 1];
                     }
+                    memset(&(fd_array[fdnum]), 0, sizeof(fd_array[fdnum]));
+                    con_array[fdnum] = NULL;
+                    i--;
                 }
             }
         }

--- a/server/src/InsituConnectorMaster.cpp
+++ b/server/src/InsituConnectorMaster.cpp
@@ -105,6 +105,12 @@ errorCode InsituConnectorMaster::run()
                     newsockfd = accept(sockfd, (struct sockaddr*) &cli_addr, &clilen);
                     if(newsockfd >= 0)
                     {
+                        if(fdnum >= MAX_SOCKETS)
+                        {
+                            fprintf(stderr, "InsituConnectorMaster: Too many connections. Closing new connection.\n");
+                            close(newsockfd);
+                            continue;
+                        }
                         InsituConnector* insituConnector = new InsituConnector(newsockfd, nextFreeNumber++);
                         insituConnector->jlcb.count = 0;
                         InsituConnectorContainer* d = new InsituConnectorContainer();
@@ -126,25 +132,23 @@ errorCode InsituConnectorMaster::run()
                 {
                     while(1)
                     {
+                        int remaining = ISAAC_MAX_RECEIVE - con_array[i]->connector->jlcb.count - 1;
+                        if(remaining <= 0)
+                        {
+                            fprintf(
+                                stderr,
+                                "Fatal error: Socket received more bytes than the %d byte buffer can hold! To increase "
+                                "the allowed size set ISAAC_MAX_RECEIVE to a higher value.\n",
+                                ISAAC_MAX_RECEIVE);
+                            return -1;
+                        }
                         int add = recv(
                             fd_array[i].fd,
                             &(con_array[i]->connector->jlcb.buffer[con_array[i]->connector->jlcb.count]),
-                            4096,
+                            remaining > 4096 ? 4096 : remaining,
                             MSG_DONTWAIT);
                         if(add > 0)
-                        {
                             con_array[i]->connector->jlcb.count += add;
-                            if(con_array[i]->connector->jlcb.count > ISAAC_MAX_RECEIVE)
-                            {
-                                fprintf(
-                                    stderr,
-                                    "Fatal error: Socket received %d bytes but buffer is only %d bytes! To increase "
-                                    "the allowed size set ISAAC_MAX_RECEIVE to a higher value.\n",
-                                    con_array[i]->connector->jlcb.count,
-                                    ISAAC_MAX_RECEIVE);
-                                return -1;
-                            }
-                        }
                         else
                             break;
                     }

--- a/server/src/TCPDataConnector.cpp
+++ b/server/src/TCPDataConnector.cpp
@@ -100,9 +100,16 @@ errorCode TCPDataConnector::run()
                     newsockfd = accept(sockfd, (struct sockaddr*) &cli_addr, &clilen);
                     if(newsockfd >= 0)
                     {
+                        if(fdnum >= MAX_SOCKETS)
+                        {
+                            fprintf(stderr, "TCPDataConnector: Too many connections. Closing new connection.\n");
+                            close(newsockfd);
+                            continue;
+                        }
                         printf("TCPDataConnector: New connection, giving id %i\n", fdnum);
                         client_array[fdnum] = broker->addDataClient();
                         jlcb_array[fdnum] = new jlcb_container();
+                        jlcb_array[fdnum]->jlcb.count = 0;
                         fd_array[fdnum].fd = newsockfd;
                         fd_array[fdnum].events = POLLIN;
                         fdnum++;
@@ -113,6 +120,7 @@ errorCode TCPDataConnector::run()
         for(int i = 1; i < fdnum; i++)
         {
             bool closed = false;
+            const bool socket_closed = (fd_array[i].revents & (POLLHUP | POLLERR | POLLNVAL)) != 0;
             // Messages of children
             while(MessageContainer* message = client_array[i]->clientGetMessage())
             {
@@ -142,52 +150,71 @@ errorCode TCPDataConnector::run()
             {
                 while(1)
                 {
+                    int remaining = ISAAC_MAX_RECEIVE - jlcb_array[i]->jlcb.count - 1;
+                    if(remaining <= 0)
+                    {
+                        fprintf(
+                            stderr,
+                            "TCPDataConnector: Socket received more bytes than the %d byte buffer can hold. Closing connection.\n",
+                            ISAAC_MAX_RECEIVE);
+                        client_array[i]->clientSendMessage(new MessageContainer(CLOSED));
+                        closed = true;
+                        break;
+                    }
                     int add = recv(
                         fd_array[i].fd,
                         &(jlcb_array[i]->jlcb.buffer[jlcb_array[i]->jlcb.count]),
-                        4096,
+                        remaining > 4096 ? 4096 : remaining,
                         MSG_DONTWAIT);
                     if(add > 0)
                         jlcb_array[i]->jlcb.count += add;
                     else
                         break;
                 }
-                jlcb_array[i]->jlcb.pos = 0;
-                jlcb_array[i]->jlcb.buffer[jlcb_array[i]->jlcb.count] = 0;
-                if(jlcb_array[i]->jlcb.count > 0)
+                if(!closed)
                 {
+                    jlcb_array[i]->jlcb.pos = 0;
                     jlcb_array[i]->jlcb.buffer[jlcb_array[i]->jlcb.count] = 0;
-                    json_error_t error;
-                    int last_working_pos = 0;
-                    while(json_t* content = json_load_callback(
-                              json_load_callback_function,
-                              &jlcb_array[i]->jlcb,
-                              JSON_DISABLE_EOF_CHECK,
-                              &error))
+                    if(jlcb_array[i]->jlcb.count > 0)
                     {
-                        last_working_pos = jlcb_array[i]->jlcb.pos;
-                        MessageContainer* message = new MessageContainer(NONE, content);
-                        json_object_set_new(
-                            message->json_root,
-                            "url",
-                            json_string("127.0.0.1")); // TODO: Using real url
-                        client_array[i]->clientSendMessage(message);
+                        jlcb_array[i]->jlcb.buffer[jlcb_array[i]->jlcb.count] = 0;
+                        json_error_t error;
+                        int last_working_pos = 0;
+                        while(json_t* content = json_load_callback(
+                                  json_load_callback_function,
+                                  &jlcb_array[i]->jlcb,
+                                  JSON_DISABLE_EOF_CHECK,
+                                  &error))
+                        {
+                            last_working_pos = jlcb_array[i]->jlcb.pos;
+                            MessageContainer* message = new MessageContainer(NONE, content);
+                            json_object_set_new(
+                                message->json_root,
+                                "url",
+                                json_string("127.0.0.1")); // TODO: Using real url
+                            client_array[i]->clientSendMessage(message);
+                        }
+                        // If the whole json message was not received yet, we need to keep the start
+                        if(error.position != 1 || strcmp(error.text, "'[' or '{' expected near end of file") != 0)
+                        {
+                            for(int j = 0; j < jlcb_array[i]->jlcb.count - last_working_pos; j++)
+                                jlcb_array[i]->jlcb.buffer[j] = jlcb_array[i]->jlcb.buffer[j + last_working_pos];
+                            jlcb_array[i]->jlcb.count -= last_working_pos;
+                        }
+                        else
+                            jlcb_array[i]->jlcb.count = 0;
                     }
-                    // If the whole json message was not received yet, we need to keep the start
-                    if(error.position != 1 || strcmp(error.text, "'[' or '{' expected near end of file") != 0)
+                    else // Closed
                     {
-                        for(int j = 0; j < jlcb_array[i]->jlcb.count - last_working_pos; j++)
-                            jlcb_array[i]->jlcb.buffer[j] = jlcb_array[i]->jlcb.buffer[j + last_working_pos];
-                        jlcb_array[i]->jlcb.count -= last_working_pos;
+                        client_array[i]->clientSendMessage(new MessageContainer(CLOSED));
+                        closed = true;
                     }
-                    else
-                        jlcb_array[i]->jlcb.count = 0;
                 }
-                else // Closed
-                {
-                    client_array[i]->clientSendMessage(new MessageContainer(CLOSED));
-                    closed = true;
-                }
+            }
+            if(socket_closed && !closed)
+            {
+                client_array[i]->clientSendMessage(new MessageContainer(CLOSED));
+                closed = true;
             }
             if(closed)
             {
@@ -199,8 +226,12 @@ errorCode TCPDataConnector::run()
                 {
                     fd_array[j] = fd_array[j + 1];
                     client_array[j] = client_array[j + 1];
+                    jlcb_array[j] = jlcb_array[j + 1];
                 }
                 memset(&(fd_array[fdnum]), 0, sizeof(fd_array[fdnum]));
+                client_array[fdnum] = NULL;
+                jlcb_array[fdnum] = NULL;
+                i--;
             }
         }
     }

--- a/server/src/WebSocketDataConnector.cpp
+++ b/server/src/WebSocketDataConnector.cpp
@@ -151,16 +151,23 @@ static int callback_isaac(struct lws* wsi, enum lws_callback_reasons reason, voi
             } while(l > 1 && !lws_send_pipe_choked(wsi));
         }
         break;
-    // case LWS_CALLBACK_CLOSED:
-    //	pss->client->clientSendMessage(new MessageContainer(CLOSED));
-    //	return -1;
+    case LWS_CALLBACK_CLOSED:
+        if(pss->client)
+        {
+            pss->client->clientSendMessage(new MessageContainer(CLOSED));
+            pss->client = NULL;
+        }
+        break;
     case LWS_CALLBACK_RECEIVE:
         if(pss->client)
         {
             json_error_t error;
             json_t* input = json_loadb((const char*) in, len, 0, &error);
             if(!input)
+            {
                 printf("JSON ERROR: %s", error.text);
+                break;
+            }
             MessageContainer* message = new MessageContainer(NONE, input);
             int finish = (message->type == CLOSED);
             json_object_set_new(message->json_root, "url", json_string(pss->url));


### PR DESCRIPTION
- [x] merge after #192

Fixed issues:  

  - WebSocket metadata clients were not removed on browser/socket close because LWS_CALLBACK_CLOSED was commented out.
  - Invalid WebSocket JSON could create a MessageContainer with NULL JSON and then dereference it.
  - TCP metadata connector:
      - did not handle POLLHUP/POLLERR/POLLNVAL
      - skipped the next connection after removing one
      - failed to shift/clear jlcb_array with the fd/client arrays
      - did not initialize jlcb.count
      - could overflow the receive buffer before checking size

  - Insitu connector master:
      - could exceed MAX_SOCKETS
      - could overflow its receive buffer before checking size