### PR TITLE
 Fix isaac library portability and MPI edge cases

### DIFF
--- a/lib/isaac.hpp
+++ b/lib/isaac.hpp
@@ -1888,7 +1888,13 @@ namespace isaac
                                 }
                             }
                             // wait for all mpi communications to be finished
-                            MPI_Waitall(mpiRequests.size(), &mpiRequests[0], MPI_STATUSES_IGNORE);
+                            if(!mpiRequests.empty())
+                            {
+                                MPI_Waitall(
+                                    static_cast<int>(mpiRequests.size()),
+                                    mpiRequests.data(),
+                                    MPI_STATUSES_IGNORE);
+                            }
 
                             // sync the received neighbour guard information with the main guards in the texture
                             syncNeighbourGuardTextures<T_Acc>(stream, advectionTextureAllocator, neighbourNodeIds);
@@ -2011,8 +2017,8 @@ namespace isaac
 
                     float pointDistance = glm::length(modelview * point);
                     // Allgather of the distances
-                    float receiveBuffer[numProc];
-                    MPI_Allgather(&pointDistance, 1, MPI_FLOAT, receiveBuffer, 1, MPI_FLOAT, mpiWorld);
+                    std::vector<float> receiveBuffer(numProc);
+                    MPI_Allgather(&pointDistance, 1, MPI_FLOAT, receiveBuffer.data(), 1, MPI_FLOAT, mpiWorld);
                     // Putting to a std::multimap of {rank, distance}
                     std::multimap<float, isaac_int, std::less<float>> distanceMap;
                     for(isaac_int i = 0; i < numProc; i++)
@@ -2020,7 +2026,7 @@ namespace isaac
                         distanceMap.insert(std::pair<float, isaac_int>(receiveBuffer[i], i));
                     }
                     // Putting in an array for IceT
-                    IceTInt icetOrderArray[numProc];
+                    std::vector<IceTInt> icetOrderArray(numProc);
                     {
                         isaac_int i = 0;
                         for(auto it = distanceMap.begin(); it != distanceMap.end(); it++)
@@ -2029,7 +2035,7 @@ namespace isaac
                             i++;
                         }
                     }
-                    icetCompositeOrder(icetOrderArray);
+                    icetCompositeOrder(icetOrderArray.data());
                     ISAAC_STOP_TIME_MEASUREMENT(sortingTime, +=, sorting, getTicksUs())
 
                     // Drawing
@@ -2046,18 +2052,19 @@ namespace isaac
 
             // Message merging
             char* buffer = json_dumps(jsonRoot, 0);
-            strcpy(messageBuffer, buffer);
+            strncpy(messageBuffer, buffer, ISAAC_MAX_RECEIVE - 1);
+            messageBuffer[ISAAC_MAX_RECEIVE - 1] = 0;
             free(buffer);
             if(metaTargets == META_MERGE)
             {
                 if(rank == master)
                 {
-                    char receiveBuffer[numProc][ISAAC_MAX_RECEIVE];
+                    std::vector<char> receiveBuffer(numProc * ISAAC_MAX_RECEIVE);
                     MPI_Gather(
                         messageBuffer,
                         ISAAC_MAX_RECEIVE,
                         MPI_CHAR,
-                        receiveBuffer,
+                        receiveBuffer.data(),
                         ISAAC_MAX_RECEIVE,
                         MPI_CHAR,
                         master,
@@ -2068,7 +2075,7 @@ namespace isaac
                         {
                             continue;
                         }
-                        json_t* js = json_loads(receiveBuffer[i], 0, NULL);
+                        json_t* js = json_loads(&receiveBuffer[i * ISAAC_MAX_RECEIVE], 0, NULL);
                         mergeJSON(jsonRoot, js);
                         json_decref(js);
                     }

--- a/lib/isaac/isaac_common_kernel.hpp
+++ b/lib/isaac/isaac_common_kernel.hpp
@@ -188,7 +188,8 @@ namespace isaac
         ray.startDepth = glm::max(ray.startDepth, isaac_float(ISAAC_Z_NEAR));
 
         // return if the ray doesn't hit the volume
-        if(ray.startDepth > ray.endDepth || isinf(ray.startDepth) || isinf(ray.endDepth))
+        if(ray.startDepth > ray.endDepth || alpaka::math::isinf(acc, ray.startDepth)
+           || alpaka::math::isinf(acc, ray.endDepth))
             return false;
 
         return true;

--- a/lib/isaac/isaac_communicator.hpp
+++ b/lib/isaac/isaac_communicator.hpp
@@ -52,6 +52,7 @@ namespace isaac
             , port(port)
             , sockfd(0)
             , jpeg_quality(90)
+            , readThreadStarted(false)
             , registerMessage(NULL)
         {
             pthread_mutex_init(&deleteMessageMutex, NULL);
@@ -88,6 +89,7 @@ namespace isaac
             sockfd = socket(AF_INET, SOCK_STREAM, 0);
             if(sockfd < 0)
             {
+                sockfd = 0;
                 if(setting == ReturnAtError)
                 {
                     fprintf(stderr, "Could not create socket.\n");
@@ -107,6 +109,7 @@ namespace isaac
             if(connect(sockfd, (struct sockaddr*) &serv_addr, sizeof(serv_addr)) < 0)
             {
                 close(sockfd);
+                sockfd = 0;
                 if(setting == ReturnAtError)
                 {
                     fprintf(stderr, "Could not connect to %s.\n", url.c_str());
@@ -118,7 +121,7 @@ namespace isaac
                     return 1;
                 }
             }
-            pthread_create(&readThread, NULL, run_readAndSetMessages, this);
+            readThreadStarted = pthread_create(&readThread, NULL, run_readAndSetMessages, this) == 0;
             return 0;
         }
 
@@ -297,7 +300,10 @@ namespace isaac
             if(sockfd)
                 serverDisconnect();
             usleep(100000); // 100ms
-            pthread_cancel(readThread);
+            if(readThreadStarted)
+            {
+                pthread_cancel(readThread);
+            }
             pthread_mutex_destroy(&deleteMessageMutex);
         }
         void setMessage(json_t* content)
@@ -343,7 +349,8 @@ namespace isaac
         }
         static size_t json_load_callback_function(void* buffer, size_t buflen, void* data)
         {
-            return recv(*((isaac_int*) data), buffer, 1, 0);
+            ssize_t const received = recv(*((isaac_int*) data), buffer, buflen, 0);
+            return received > 0 ? static_cast<size_t>(received) : 0u;
         }
         static void* run_readAndSetMessages(void* communicator)
         {
@@ -359,6 +366,7 @@ namespace isaac
         std::list<json_t*> messageList;
         pthread_mutex_t deleteMessageMutex;
         pthread_t readThread;
+        bool readThreadStarted;
         json_t** registerMessage;
     };
 


### PR DESCRIPTION
  - lib/isaac/isaac_common_kernel.hpp - Replaced unqualified isinf(...) in device code with alpaka::math::isinf(acc, ...) for alpaka/backend portability.

  - lib/isaac.hpp
      - Guarded MPI_Waitall against empty request vectors and used data().
      - Replaced non-standard C++ variable-length arrays with std::vector. - Replaced unsafe strcpy into fixed-size messageBuffer with bounded copy.

  - lib/isaac/isaac_communicator.hpp - Avoided cancelling an uninitialized pthread_t. - Reset socket state after failed socket/connect paths. - Made the Jansson receive callback handle recv errors/EOF safely