### PR TITLE
Update install guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,18 +11,18 @@ be built yourself nevertheless or the distribution versions are outdated.
 
 ### Requirements for the server and the in situ library
 
-* __gcc__ / __g++__ for compiling the program at all. Version 4.8 __should__
-  work, but 4.9 is recommended:
+* __gcc__ / __g++__ for compiling the program at all. At least version 10
+  should be used:
   * _Debian/Ubuntu_:
-    * `sudo apt-get install gcc-4.9 g++-4.9 build-essential`
-* __CMake__ for building everything:
+    * `sudo apt-get install gcc-10 g++-10 build-essential`
+* __CMake__ 3.25.2+ for building everything:
   * _Debian/Ubuntu_:
     * `sudo apt-get install cmake cmake-curses-gui`
-  * _From Source_ (As at least Version 3.3 is needed for the in-situ library):
-    * `wget https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz`
-    * `tar -zxvf cmake-3.5.2.tar.gz`
-    * `rm cmake-3.5.2.tar.gz`
-    * `cd cmake-3.5.2`
+  * _From Source_:
+    * `wget https://cmake.org/files/v3.28/cmake-3.28.6.tar.gz`
+    * `tar -xzf cmake-3.28.6.tar.gz`
+    * `rm cmake-3.28.6.tar.gz`
+    * `cd cmake-3.28.6`
     * With admin rights and no other version of cmake installed:
       * `./configure`
       * `make`
@@ -30,19 +30,18 @@ be built yourself nevertheless or the distribution versions are outdated.
     * Otherwise:
       * `mkdir install`
       * `./configure --prefix=$CMAKE/install`, where where `$CMAKE` is
-        the full (!) path of the cmake-3.5.2 directory.
+        the full (!) path of the cmake-3.28.6 directory.
       * `make install`
       * Now a local version of CMake is installed in the install directory in
-        the cmake-3.5.2 folder. Later while compiling an application using
+        the cmake-3.28.6 folder. Later while compiling an application using
         CMake (including the ISAAC server and the ISAAC examples) use
         `$CMAKE/install/bin/cmake` instead of `cmake` and
         `$CMAKE/install/bin/ccmake` instead of `ccmake`, where `$CMAKE` is
-        the path of the cmake-3.5.2 directory used above.
-* __libjpeg__ or __libjpeg-turbo__ for (de)compressing the rendered image of the
-  transmission:
+        the path of the cmake-3.28.6 directory used above.
+* __libjpeg-turbo__ for (de)compressing the rendered image of the transmission:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libjpeg-dev`
-* __Jansson__ for the de- and encryption of the JSON messages transfered
+* __Jansson__ 2.12+ for the de- and encryption of the JSON messages transfered
   between server and client.
   * _Debian/Ubuntu_:
     * `sudo apt-get install libjansson-dev`
@@ -65,15 +64,15 @@ be built yourself nevertheless or the distribution versions are outdated.
         Jansson (including the ISAAC server and the ISAAC examples) add
         `-DJansson_DIR=$JANSSON/install/lib/cmake/jansson`, where `$JANSSON` is
         the root folder of the Jansson source (the directory `git clone …` created).
-* __Boost__ (at least 1.56) is needed, but only template libraries, so no
+* __Boost__ 1.70+ is needed, but only template libraries, so no
   system wide installation or static linking is needed here:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libboost-dev`
   * _From Source_:
-    * `wget http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz/download -O boost_1_56_0.tar.gz`
-    * `tar -zxvf boost_1_56_0.tar.gz`
-    * `rm boost_1_56_0.tar.gz`
-    * `cd boost_1_56_0`
+    * `wget https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz`
+    * `tar -xzf boost_1_87_0.tar.gz`
+    * `rm boost_1_87_0.tar.gz`
+    * `cd boost_1_87_0`
     * With admin rights and no other version of boost installed:
       * `./bootstrap.sh`
       * `./b2`
@@ -81,20 +80,20 @@ be built yourself nevertheless or the distribution versions are outdated.
     * Otherwise:
       * `mkdir install`
       * `./bootstrap.sh --prefix=$BOOST/install`, where where `$BOOST` is
-        the full (!) path of the boost_1_56_0 directory.
+        the full (!) path of the boost_1_87_0 directory.
       * `./b2 install`
       * Now a local version of Boost is installed in the install directory in
-        the boost_1_56_0 folder. Later while compiling an application using
+        the boost_1_87_0 folder. Later while compiling an application using
         Boost (including the ISAAC server and the ISAAC examples) add
         `-DBoost_DIR=$BOOST/install`, where `$BOOST` is
-        the path of the boost_1_56_0 directory.
+        the path of the boost_1_87_0 directory.
 
 ### Requirements for the in situ library and the examples using it
 
 The ISAACConfig.cmake searches for these requirements. See
 `example/CMakeLists.txt` for an easy to adopt example.
 
-* __alpaka__ (version 0.9.0) for the abstraction of the acceleration device. If only CUDA
+* __alpaka__ 2.0.0+ for the abstraction of the acceleration device. If only CUDA
   is used, this library is __not needed__:
   * _From Source_:
     * `git clone https://github.com/alpaka-group/alpaka.git`
@@ -164,9 +163,9 @@ The ISAACConfig.cmake searches for these requirements. See
         CMake variable `CMAKE_MODULE_PATH` to use this version.
 * __glm__ 1.0.0+ for the internal math types and functions
   * _From Source_:
-    * `git clone https://github.com/g-truc/glm.git` --depth 1 --branch 1.0.1
+    * `git clone https://github.com/g-truc/glm.git --depth 1 --branch 1.0.3`
     * `cd glm`
-    * `export GLM_ROOT=`pwd`/1.0.1`
+    * `export GLM_ROOT=`pwd`/1.0.3`
     * `mkdir $GLM_ROOT`
     * `mkdir build`
     * `cd build`
@@ -177,10 +176,9 @@ The ISAACConfig.cmake searches for these requirements. See
 
 ### Requirements for the server only
 
-* __libwebsockets__ for the connection between server and an HTML5 client.
-  It is in steady development and the most recent version should be used:
+* __libwebsockets__ 2.1.1+ for the connection between server and an HTML5 client.
   * _From Source_:
-    * `git clone https://github.com/warmcat/libwebsockets.git`
+    * `git clone https://github.com/warmcat/libwebsockets.git --depth 1 --branch v4.5-stable`
     * `cd libwebsockets`
     * `mkdir build`
     * With admin rights and no other version of libwebsockets installed:
@@ -213,7 +211,7 @@ The ISAACConfig.cmake searches for these requirements. See
   streams of a server without gStreamer. If gStreamer is not found, it is
   deactivated by default.
   * _Debian/Ubuntu_:
-    * `sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base0.10-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev`
+    * `sudo apt-get install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libgstreamer-plugins-bad1.0-0`
 
 Building
 --------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,7 +100,7 @@ be built yourself nevertheless or the distribution versions are outdated.
 ### Requirements for the in situ library and the examples using it
 
 The ISAACConfig.cmake searches for these requirements. See
-`example/CMakeLists.txt` for an easy to adopt example.
+[`example/CMakeLists.txt`](./example/CMakeLists.txt) for an easy to adopt example.
 
 * __alpaka__ 2.0.0+ for the abstraction of the acceleration device:
   * _From Source_:
@@ -214,9 +214,9 @@ Building
 
 ### Installing the library
 
-To install the isaac library to use it in your project
-go to directory `lib` inside the isaac root folder, create a folder like
-`build` and do the classic cmake magic:
+To install the isaac library to use it in your project, go to directory `lib`
+inside the isaac root folder, create a folder like `build`, and do the classic 
+cmake magic:
 
 * `git clone https://github.com/ComputationalRadiationPhysics/isaac.git`
 * `cd isaac`
@@ -251,11 +251,11 @@ isaac (`cd isaac`) do:
 * `make install`
 
 Afterwards you get the executable `isaac_example`.
-For running these examples you need a running isaac server.
+To run this example, you need a running isaac server.
 
 ### The server
 
-The server resides in the direcoty `server` and also uses CMake:
+The server resides in the directory `server` and also uses CMake:
 
 * `cd isaac`
 * `cd server`
@@ -282,28 +282,32 @@ If you want to install the server type
 
 * (`sudo`) `make install`
 
-Change the installation directory with adding
+Change the installation directory by adding
 
 * `-DCMAKE_INSTALL_PREFIX=/your/path`
 
 in the initial `cmake ..`
 
-However, the server doesn't need to be installed and can also directly be called with
+However, the server doesn't need to be installed and can also directly be called
+from the build directory with
 
 * `./isaac`
 
-For more informations about parameters use `./isaac --help` or have
-a look in the __[server documentation](http://computationalradiationphysics.github.io/isaac/doc/server/index.html)__.
+For more informations about parameters use `./isaac --help` or have a look in
+the __[server documentation](https://computationalradiationphysics.github.io/isaac/doc/server/index.html)__.
 
 ### Testing
 
-To test the server and an example, just start the server with `./isaac`,
-connect to it with one of the HTML clients in the directory `client` (best
-is `interface.htm`) and start an example with `./example_cuda` or
-`./example_alpaka`. It should connect to the server running on localhost and be
-observable and steerable. You can run multiple instances of the example with
-`mpirun -c N ./example_KIND` with the number of instances `N` and `KIND`
-being `cuda` or `alpaka`. To exit the example, use the client or ctrl+C.
+To test the server and an example, just start the server with `./isaac`, connect
+to it with one of the HTML clients in the directory `client` (best is
+`visualisation.html`) and start an example with `./isaac_example`. It should
+connect to the server running on localhost and be observable and steerable. You
+can run multiple instances of the example with `mpirun -c N ./isaac_example`
+with the number of instances `N`. To exit the example, use the client or ctrl+C.
+
+If the client and the isaac server are not located on the same system, it might
+be required to create a tunnel between the two systems. In that case, you may
+want to have a look into the __[tunnel guide](./TUNNEL.md)__.
 
 ### Versions
 
@@ -331,5 +335,5 @@ be used.
 How to use in an own application
 --------------------------------
 
-For a deeper insight how to use ISAAC in a new application, have a look
-at the [library documentation](http://computationalradiationphysics.github.io/isaac/doc/library/index.html).
+For a deeper insight how to use ISAAC in a new application, have a look at the
+__[library documentation](https://computationalradiationphysics.github.io/isaac/doc/library/index.html)__.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,6 +41,19 @@ be built yourself nevertheless or the distribution versions are outdated.
 * __libjpeg-turbo__ for (de)compressing the rendered image of the transmission:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libjpeg-dev`
+  * _From Source_:
+    * You might need to install [__nasm__](https://nasm.us/), as building 
+      libjpeg-turbo requires it.
+    * `git clone https://github.com/libjpeg-turbo/libjpeg-turbo.git`
+    * `cd libjpeg-turbo`
+    * `mkdir build && cd build`
+    * With admin rights and no other version of libjpeg-turbo installed:
+      * `cmake ..`
+      * `make`
+      * `sudo make install`
+    * Otherwise:
+      * `cmake .. -DCMAKE_INSTALL_PREFIX=$LIBJPEG_INSTALL_DIR`
+      * `make install`
 * __Jansson__ 2.12+ for the de- and encryption of the JSON messages transfered
   between server and client.
   * _Debian/Ubuntu_:
@@ -142,22 +155,23 @@ The ISAACConfig.cmake searches for these requirements. See
   * _Debian/Ubuntu_:
     * `sudo apt-get install libopenmpi-dev`
   * _From Source_:
-    * `git clone https://github.com/open-mpi/ompi.git`
-    * `cd ompi`
-    * `./autogen.pl`
+    * `wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.10.tar.gz`
+    * `tar -xzf openmpi-5.0.10.tar.gz`
+    * `rm openmpi-5.0.10.tar.gz`
+    * `cd openmpi-5.0.10`
+    * `mkdir build && cd build`
     * With admin rights and no other version of OpenMPI installed:
-      * `./configure`
+      * `../configure`
       * `make`
       * `sudo make install`
     * Otherwise:
-      * `mkdir install`
-      * `./configure --prefix=$MPI/install`, where `$MPI` is
-        the full (!) path of the openMPI directory.
+      * `../configure --prefix=$MPI_INSTALL_DIR`, where `$MPI_INSTALL_DIR` is
+        the full (!) path to the directory where OpenMPI should be installed.
       * `make install`
-      * Now a local version of OpenMPI is installed in the install directory in
-        the OpenMPI folder. Later while compiling an application using
-        MPI (including the ISAAC examples) add `$MPI/install` to the
-        CMake variable `CMAKE_MODULE_PATH` to use this version.
+      * Now, a local version of OpenMPI is installed in the specified install
+        directory. Later while compiling an application using MPI (including the
+        ISAAC examples) add `$MPI_INSTALL_DIR` to the CMake variable
+        `CMAKE_MODULE_PATH` to use this version.
 * __glm__ 1.0.0+ for the internal math types and functions
   * _From Source_:
     * `git clone https://github.com/g-truc/glm.git --depth 1 --branch 1.0.3`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,16 +28,15 @@ be built yourself nevertheless or the distribution versions are outdated.
       * `make`
       * `sudo make install`
     * Otherwise:
-      * `mkdir install`
-      * `./configure --prefix=$CMAKE/install`, where where `$CMAKE` is
-        the full (!) path of the cmake-3.28.6 directory.
+      * `./configure --prefix=$CMAKE_INSTALL_DIR`, where `$CMAKE_INSTALL_DIR`
+      is the full path to the directory where cmake-3.28.6 should be installed.
       * `make install`
-      * Now a local version of CMake is installed in the install directory in
-        the cmake-3.28.6 folder. Later while compiling an application using
-        CMake (including the ISAAC server and the ISAAC examples) use
-        `$CMAKE/install/bin/cmake` instead of `cmake` and
-        `$CMAKE/install/bin/ccmake` instead of `ccmake`, where `$CMAKE` is
-        the path of the cmake-3.28.6 directory used above.
+      * Now, a local version of CMake is installed in the specified install
+        directory. Later, while compiling an application using CMake (including
+        the ISAAC server and the ISAAC examples), use `$CMAKE_INSTALL_DIR/bin/cmake`
+        instead of `cmake` and `$CMAKE_INSTALL_DIR/bin/ccmake` instead of
+        `ccmake`, where `$CMAKE_INSTALL_DIR` is the path of the cmake-3.28.6
+        install directory used above.
 * __libjpeg-turbo__ for (de)compressing the rendered image of the transmission:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libjpeg-dev`
@@ -61,22 +60,20 @@ be built yourself nevertheless or the distribution versions are outdated.
   * _From Source_:
     * `git clone https://github.com/akheron/jansson.git`
     * `cd jansson`
-    * `mkdir build`
-    * With admin rights and no other version of libjpeg installed:
-      * `cd build`
+    * `mkdir build && cd build`
+    * With admin rights and no other version of jansson installed:
       * `cmake ..`
       * `make`
       * `sudo make install`
     * Otherwise:
-      * `mkdir install`
-      * `cd build`
-      * `cmake .. -DCMAKE_INSTALL_PREFIX=../install`
+      * `cmake .. -DCMAKE_INSTALL_PREFIX=$JANSSON_INSTALL_DIR`
       * `make install`
-      * Now a local version of Jansson is installed in the install directory in
-        the Jansson root folder. Later while compiling an application using
-        Jansson (including the ISAAC server and the ISAAC examples) add
-        `-DJansson_DIR=$JANSSON/install/lib/cmake/jansson`, where `$JANSSON` is
-        the root folder of the Jansson source (the directory `git clone …` created).
+      * Now, a local version of Jansson is installed in the specified install
+        directory. Later, while compiling an application using Jansson
+        (including the ISAAC server and the ISAAC examples), add
+        `-Djansson_DIR=$JANSSON_INSTALL_DIR/lib/cmake/jansson`, where
+        `$JANSSON_INSTALL_DIR` is the path of the Jansson install directory
+        used above.
 * __Boost__ 1.70+ is needed, but only template libraries, so no
   system wide installation or static linking is needed here:
   * _Debian/Ubuntu_:
@@ -91,15 +88,14 @@ be built yourself nevertheless or the distribution versions are outdated.
       * `./b2`
       * `sudo ./b2 install`
     * Otherwise:
-      * `mkdir install`
-      * `./bootstrap.sh --prefix=$BOOST/install`, where where `$BOOST` is
-        the full (!) path of the boost_1_87_0 directory.
+      * `./bootstrap.sh --prefix=$BOOST_INSTALL_DIR`, where `$BOOST_INSTALL_DIR`
+        is the full path to the directory where Boost should be installed.
       * `./b2 install`
-      * Now a local version of Boost is installed in the install directory in
-        the boost_1_87_0 folder. Later while compiling an application using
-        Boost (including the ISAAC server and the ISAAC examples) add
-        `-DBoost_DIR=$BOOST/install`, where `$BOOST` is
-        the path of the boost_1_87_0 directory.
+      * Now, a local version of Boost is installed in the specified install
+        directory. Later, while compiling an application using Boost (including
+        the ISAAC server and the ISAAC examples), add
+        `-DBoost_DIR=$BOOST_INSTALL_DIR`, where `$BOOST_INSTALL_DIR` is the path
+        of the Boost install directory used above.
 
 ### Requirements for the in situ library and the examples using it
 
@@ -115,8 +111,7 @@ The ISAACConfig.cmake searches for these requirements. See
       below).
     * `git clone https://github.com/alpaka-group/alpaka.git`
     * `cd alpaka`
-    * `mkdir build`
-    * `cd build`
+    * `mkdir build && cd build`
     * `cmake .. -DCMAKE_INSTALL_PREFIX=$ALPAKA_INSTALL_DIR -Dalpaka_ACC_GPU_CUDA_ENABLE=ON`.
       The last option only must be included if acceleration on Nvidia GPUs is
       wanted. Go to the [alpaka manual](https://alpaka.readthedocs.io/en/stable/advanced/cmake.html#arguments)
@@ -132,23 +127,18 @@ The ISAACConfig.cmake searches for these requirements. See
   * _From Source_:
     * `git clone https://gitlab.kitware.com/icet/icet.git`
     * `cd icet`
-    * `mkdir build`
+    * `mkdir build && cd build`
     * With admin rights and no other version of IceT installed:
-      * `cd build`
       * `cmake ..`
       * `make`
       * `sudo make install`
     * Otherwise:
-      * `mkdir install`
-      * `cd build`
-      * `cmake .. -DCMAKE_INSTALL_PREFIX=../install`
+      * `cmake .. -DCMAKE_INSTALL_PREFIX=$ICET_INSTALL_DIR`
       * `make install`
-      * Now a local version of IceT is installed in the install
-        directory in the IceT root folder. Later while compiling
-        an application using ISAAC (including the examples) add
-        `-DIceT_DIR=$ICET/install`, where
-        `$ICET` is the root folder of IceT (the directory
-        `git clone …` created).
+      * Now, a local version of IceT is installed in the specified install
+        directory. Later, while compiling an application using ISAAC (including
+        the examples), add `-DIceT_DIR=$ICET_INSTALL_DIR`, where
+        `$ICET_INSTALL_DIR` is the path of the IceT install directory used above.
 * __MPI__ for the communication on the cluster. This should be available on
   all clusters these days. However for a local testsystem OpenMPI is a commonly used
   version:
@@ -176,14 +166,12 @@ The ISAACConfig.cmake searches for these requirements. See
   * _From Source_:
     * `git clone https://github.com/g-truc/glm.git --depth 1 --branch 1.0.3`
     * `cd glm`
-    * `export GLM_ROOT=`pwd`/1.0.3`
-    * `mkdir $GLM_ROOT`
-    * `mkdir build`
-    * `cd build`
-    * `cmake ../ -DCMAKE_INSTALL_PREFIX=$GLM_ROOT -DGLM_TEST_ENABLE=OFF`
+    * `mkdir build && cd build`
+    * `cmake .. -DCMAKE_INSTALL_PREFIX=$GLM_INSTALL_DIR -DGLM_TEST_ENABLE=OFF`
     * `make install`
-    * export `GLM_ROOT` to your cmake prefix path (and add this to e.g. your profile)
-      * `export CMAKE_PREFIX_PATH=$GLM_ROOT:$CMAKE_PREFIX_PATH`
+    * export `GLM_INSTALL_DIR` to your cmake prefix path (and add this to e.g.
+      your profile)
+      * `export CMAKE_PREFIX_PATH=$GLM_INSTALL_DIR:$CMAKE_PREFIX_PATH`
 
 ### Requirements for the server only
 
@@ -191,30 +179,27 @@ The ISAACConfig.cmake searches for these requirements. See
   * _From Source_:
     * `git clone https://github.com/warmcat/libwebsockets.git --depth 1 --branch v4.5-stable`
     * `cd libwebsockets`
-    * `mkdir build`
+    * `mkdir build && cd build`
     * With admin rights and no other version of libwebsockets installed:
-      * `cd build`
       * `cmake ..`
-        * `cmake ..` may fail if OpenSSL is not available. ISAAC itself does
+        * This may fail if OpenSSL is not available. ISAAC itself does
           not support HTTPS connections at the moment anyway, thus it can be
           disabled with: `cmake -DLWS_WITH_SSL=OFF ..`
       * `make`
       * `sudo make install`
     * Otherwise:
-      * `mkdir install`
-      * `cd build`
-      * `cmake -DCMAKE_INSTALL_PREFIX=../install ..`
-        * `cmake -DCMAKE_INSTALL_PREFIX=../install ..` may fail if OpenSSL
-          is not available. ISAAC itself does not support HTTPS connections at
-          the moment anyway, thus it can be disabled with:
-          `cmake -DLWS_WITH_SSL=OFF -DCMAKE_INSTALL_PREFIX=../install ..`
+      * `cmake -DCMAKE_INSTALL_PREFIX=$LIBWEBSOCKETS_INSTALL_DIR ..`
+        * This may fail if OpenSSL is not available. ISAAC itself does
+          not support HTTPS connections at the moment anyway, thus it can be
+          disabled with:
+          `cmake -DLWS_WITH_SSL=OFF -DCMAKE_INSTALL_PREFIX=$LIBWEBSOCKETS_INSTALL_DIR ..`
       * `make install`
-      * Now a local version of libwebsockets is installed in the install
-        directory in the libwebsockets root folder. Later while compiling the
-        ISAAC server using libwebsockets add
-        `-DLibwebsockets_DIR=$LIBWEBSOCKETS/install/lib/cmake/libwebsockets`, where
-        `$LIBWEBSOCKETS` is the root folder of the libwebsockets source (the directory
-        `git clone …` created).
+      * Now, a local version of libwebsockets is installed in the specified
+        install directory. Later, while compiling the ISAAC server using
+        libwebsockets, add
+        `-DLibwebsockets_DIR=$LIBWEBSOCKETS_INSTALL_DIR/lib/cmake/libwebsockets`,
+        where `$LIBWEBSOCKETS_INSTALL_DIR` is the path of the libwebsockets 
+        install directory used above.
 * __gStreamer__ is only needed, if streaming over RTP or the Twitch plugin shall
   be used. It should be possible to build gStreamer yourself, but it
   is strongly adviced - even from the gStreamer team themself - to use
@@ -236,9 +221,8 @@ go to directory `lib` inside the isaac root folder, create a folder like
 * `git clone https://github.com/ComputationalRadiationPhysics/isaac.git`
 * `cd isaac`
 * `cd lib`
-* `mkdir build`
-* `cd build`
-* `cmake ..`
+* `mkdir build && cd build`
+* `cmake -DCMAKE_INSTALL_PREFIX=$ISAAC_LIB_DIR ..`
 * (`sudo`) ` make install`
 
 You don't need to call `make` before `make install` as the template library
@@ -251,12 +235,11 @@ the examples is the folder `example`, so after changing directory to
 isaac (`cd isaac`) do:
 
 * `cd example`
-* `mkdir build`
-* `cd build`
+* `mkdir build && cd build`
 * `cmake ..`
   * Don't forget the maybe needed `-DLIB_DIR=…` parameters
     needed for local installed libraries. E.g.
-    `cmake -DIceT_DIR=$ICET/install/lib ..`
+    `cmake -DIceT_DIR=$ICET_INSTALL_DIR/lib ..`
   * There are some options to (de)activate features of the library if they are
     not needed or not available on the system (like Cuda/HIP), which you can
     change with these lines before `..` (in `cmake ..`) or afterwards with
@@ -265,7 +248,7 @@ isaac (`cd isaac`) do:
       Activates the CUDA / HIP accelerator in Alpaka. The used accelerator of
       ISAAC can be changed inside the file `example.cpp`, where at default CUDA
       is used as accelerator.
-* `make`
+* `make install`
 
 Afterwards you get the executable `isaac_example`.
 For running these examples you need a running isaac server.
@@ -276,27 +259,28 @@ The server resides in the direcoty `server` and also uses CMake:
 
 * `cd isaac`
 * `cd server`
-* `mkdir build`
-* `cd build`
+* `mkdir build && cd build`
 * `cmake ..`
   * Don't forget the maybe needed `-DLIB_DIR=…` parameters
     needed for local installed libraries. E.g.
-    `cmake -DLibwebsockets_DIR=$LIBWEBSOCKETS/install/lib/cmake/libwebsockets ..`
-  * There are some options to (de)activate features of the server if they are not needed
-    or not available on the system (like Gstreamer), which you can change with
-    theese lines before `..` (in `cmake ..`) or afterwards with `ccmake` or `cmake-gui`:
+    `cmake -DLibwebsockets_DIR=$LIBWEBSOCKETS_INSTALL_DIR/lib/cmake/libwebsockets ..`
+  * There are some options to (de)activate features of the server if they are
+    not needed or not available on the system (like Gstreamer), which you can
+    change with these lines before `..` (in `cmake ..`) or afterwards with
+    `ccmake` or `cmake-gui`:
     * `-DISAAC_GST=OFF` → Deactivates GStreamer (Default if not found).
-    * `-DISAAC_JPEG=OFF` → Deactivates JPEG compression. As already mentioned: This is not advised
-      and will most probably leave ISAAC in an unusable state in the end.
-    * `-DISAAC_SDL=ON` → Activates a plugin for showing the oldest not yet finished
-      visualization in an extra window using `libSDL`. Of course this option does not
-      make much sense for most servers as they don't have a screen or even an
-      X server installed.
+    * `-DISAAC_JPEG=OFF` → Deactivates JPEG compression. As already mentioned:
+      This is not advised and will most probably leave ISAAC in an unusable
+      state in the end.
+    * `-DISAAC_SDL=ON` → Activates a plugin for showing the oldest not yet
+      finished visualization in an extra window using `libSDL`. Of course, this
+      option does not make much sense for most servers, as they don't have a
+      screen or even an X server installed.
 * `make`
 
 If you want to install the server type
 
-* `make install` (probably as root)
+* (`sudo`) `make install`
 
 Change the installation directory with adding
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,7 +116,7 @@ The ISAACConfig.cmake searches for these requirements. See
       The last option only must be included if acceleration on Nvidia GPUs is
       wanted. Go to the [alpaka manual](https://alpaka.readthedocs.io/en/stable/advanced/cmake.html#arguments)
       for infos on how to use other accelerators.
-    * `cmake --install .`
+    * `make install`
     * Later, while compiling an application using alpaka (including the ISAAC
       examples), add `-Dalpaka_DIR=$ALPAKA_INSTALL_DIR`, where
       `$ALPAKA_INSTALL_DIR` is the path of the alpaka install directory used

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,8 @@ ISAAC Install Guide
 Requirements
 ------------
 
-Most dependencies are part of most distributions. However some need to
-be built yourself nevertheless or the distribution versions are outdated.
+Most dependencies are part of most distributions. However, some need to
+be built yourself nevertheless, or the distribution versions are outdated.
 
 ### Requirements for the server and the in situ library
 
@@ -54,7 +54,7 @@ be built yourself nevertheless or the distribution versions are outdated.
       * `cmake .. -DCMAKE_INSTALL_PREFIX=$LIBJPEG_INSTALL_DIR`
       * `make install`
 * __Jansson__ 2.12+ for the de- and encryption of the JSON messages transfered
-  between server and client.
+  between server and client:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libjansson-dev`
   * _From Source_:
@@ -74,8 +74,8 @@ be built yourself nevertheless or the distribution versions are outdated.
         `-Djansson_DIR=$JANSSON_INSTALL_DIR/lib/cmake/jansson`, where
         `$JANSSON_INSTALL_DIR` is the path of the Jansson install directory
         used above.
-* __Boost__ 1.70+ is needed, but only template libraries, so no
-  system wide installation or static linking is needed here:
+* __Boost__ 1.70+ is needed, but only template libraries, so no system wide
+  installation or static linking is needed here:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libboost-dev`
   * _From Source_:
@@ -121,7 +121,7 @@ The ISAACConfig.cmake searches for these requirements. See
       examples), add `-Dalpaka_DIR=$ALPAKA_INSTALL_DIR`, where
       `$ALPAKA_INSTALL_DIR` is the path of the alpaka install directory used
       above.
-* __IceT__ for combining the visualization created by the in situ plugin.
+* __IceT__ for combining the visualization created by the in situ plugin:
   * _Debian/Ubuntu_ (as part of Paraview):
     * `sudo apt-get install paraview-dev`
   * _From Source_:
@@ -139,9 +139,9 @@ The ISAACConfig.cmake searches for these requirements. See
         directory. Later, while compiling an application using ISAAC (including
         the examples), add `-DIceT_DIR=$ICET_INSTALL_DIR`, where
         `$ICET_INSTALL_DIR` is the path of the IceT install directory used above.
-* __MPI__ for the communication on the cluster. This should be available on
-  all clusters these days. However for a local testsystem OpenMPI is a commonly used
-  version:
+* __MPI__ for the communication on the cluster. This should be available on all
+  clusters these days. However, for a local test system, OpenMPI is a commonly
+  used version:
   * _Debian/Ubuntu_:
     * `sudo apt-get install libopenmpi-dev`
   * _From Source_:
@@ -162,7 +162,7 @@ The ISAACConfig.cmake searches for these requirements. See
         directory. Later while compiling an application using MPI (including the
         ISAAC examples) add `$MPI_INSTALL_DIR` to the CMake variable
         `CMAKE_MODULE_PATH` to use this version.
-* __glm__ 1.0.0+ for the internal math types and functions
+* __glm__ 1.0.0+ for the internal math types and functions:
   * _From Source_:
     * `git clone https://github.com/g-truc/glm.git --depth 1 --branch 1.0.3`
     * `cd glm`
@@ -175,7 +175,7 @@ The ISAACConfig.cmake searches for these requirements. See
 
 ### Requirements for the server only
 
-* __libwebsockets__ 2.1.1+ for the connection between server and an HTML5 client.
+* __libwebsockets__ 2.1.1+ for the connection between server and an HTML5 client:
   * _From Source_:
     * `git clone https://github.com/warmcat/libwebsockets.git --depth 1 --branch v4.5-stable`
     * `cd libwebsockets`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,29 +93,26 @@ be built yourself nevertheless or the distribution versions are outdated.
 The ISAACConfig.cmake searches for these requirements. See
 `example/CMakeLists.txt` for an easy to adopt example.
 
-* __alpaka__ 2.0.0+ for the abstraction of the acceleration device. If only CUDA
-  is used, this library is __not needed__:
+* __alpaka__ 2.0.0+ for the abstraction of the acceleration device:
   * _From Source_:
+    * __Boost__ should be installed before this, as alpaka may use it as a
+      dependency.
+    * alpaka supports multiple accelerators. If one wants to run ISAAC on GPU,
+      __Cuda__ or __HIP__ should be installed beforehand and activated (see
+      below).
     * `git clone https://github.com/alpaka-group/alpaka.git`
-    * It is a header only library and doesn't need to be installed. However
-      the root directory of the libary has to be added to the CMake variable
-      `CMAKE_MODULE_PATH`, e.g. with
-      * `set(ALPAKA_ROOT "${CMAKE_SOURCE_DIR}/alpaka/" CACHE STRING  "The location of the alpaka library")`
-      * `set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ALPAKA_ROOT}")`
-* __CUDA__ for Nvidia accelerators. At least version 7.0 is needed for ISAAC (if
-  CUDA acceleration is needed at all). If only OpenMP or TBB via Alpaka are used,
-  CUDA is __not needed__.
-  * _Debian/Ubuntu_ (official repositories, at least Ubuntu 16.04 for CUDA 7.0):
-    * `sudo apt-get install nvidia-cuda-dev`
-  * _Debian/Ubuntu_ (directly from NVidia):
-    * Download the most recent CUDA toolkit from here
-      `https://developer.nvidia.com/cuda-downloads`. Choose `deb (network)`
-      to download a package, which installs the NVidia repository.
-    * In the download folder of the package above do:
-      * `sudo dpkg -i cuda-repo-ubuntu1404_7.5-18_amd64.deb` (the name may differ,
-        check what you downloaded)
-      * `sudo apt-get update`
-      * `sudo apt-get install cuda`
+    * `cd alpaka`
+    * `mkdir build`
+    * `cd build`
+    * `cmake .. -DCMAKE_INSTALL_PREFIX=$ALPAKA_INSTALL_DIR -Dalpaka_ACC_GPU_CUDA_ENABLE=ON`.
+      The last option only must be included if acceleration on Nvidia GPUs is
+      wanted. Go to the [alpaka manual](https://alpaka.readthedocs.io/en/stable/advanced/cmake.html#arguments)
+      for infos on how to use other accelerators.
+    * `cmake --install .`
+    * Later, while compiling an application using alpaka (including the ISAAC
+      examples), add `-Dalpaka_DIR=$ALPAKA_INSTALL_DIR`, where
+      `$ALPAKA_INSTALL_DIR` is the path of the alpaka install directory used
+      above.
 * __IceT__ for combining the visualization created by the in situ plugin.
   * _Debian/Ubuntu_ (as part of Paraview):
     * `sudo apt-get install paraview-dev`
@@ -246,16 +243,17 @@ isaac (`cd isaac`) do:
   * Don't forget the maybe needed `-DLIB_DIR=…` parameters
     needed for local installed libraries. E.g.
     `cmake -DIceT_DIR=$ICET/install/lib ..`
-  * There are some options to (de)activate features of the library if they are not needed
-    or not available on the system (like Cuda), which you can change with
-    theese lines before `..` (in `cmake ..`) or afterwards with `ccmake` or `cmake-gui`:
-    * `-DISAAC_CUDA=OFF` →  Deactivates CUDA.
-    * `-DISAAC_ALPAKA=ON` → Activates ALPAKA. The used accelerator of Alpaka can be
-      changed inside the file `example.cpp`. At default OpenMP version 2 is used as
-      accelerator. At least CUDA or Alpaka need to be activated. 
+  * There are some options to (de)activate features of the library if they are
+    not needed or not available on the system (like Cuda/HIP), which you can
+    change with these lines before `..` (in `cmake ..`) or afterwards with
+    `ccmake` or `cmake-gui`:
+    * `-Dalpaka_ACC_GPU_CUDA_ENABLE=ON` or `-Dalpaka_ACC_GPU_HIP_ENABLE=ON` →
+      Activates the CUDA / HIP accelerator in Alpaka. The used accelerator of
+      ISAAC can be changed inside the file `example.cpp`, where at default CUDA
+      is used as accelerator.
 * `make`
 
-Afterwards you get the executables `example_cuda`, `example_alpaka` or both.
+Afterwards you get the executable `isaac_example`.
 For running these examples you need a running isaac server.
 
 ### The server

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,8 @@ be built yourself nevertheless, or the distribution versions are outdated.
   * _From Source_:
     * You might need to install [__nasm__](https://nasm.us/), as building 
       libjpeg-turbo requires it.
-    * `git clone https://github.com/libjpeg-turbo/libjpeg-turbo.git`
+    * `git clone https://github.com/libjpeg-turbo/libjpeg-turbo.git --depth 1 
+      --branch 3.1.4.1`
     * `cd libjpeg-turbo`
     * `mkdir build && cd build`
     * With admin rights and no other version of libjpeg-turbo installed:
@@ -58,7 +59,8 @@ be built yourself nevertheless, or the distribution versions are outdated.
   * _Debian/Ubuntu_:
     * `sudo apt-get install libjansson-dev`
   * _From Source_:
-    * `git clone https://github.com/akheron/jansson.git`
+    * `git clone https://github.com/akheron/jansson.git --depth 1 
+      --branch v2.15.0`
     * `cd jansson`
     * `mkdir build && cd build`
     * With admin rights and no other version of jansson installed:
@@ -109,10 +111,12 @@ The ISAACConfig.cmake searches for these requirements. See
     * alpaka supports multiple accelerators. If one wants to run ISAAC on GPU,
       __Cuda__ or __HIP__ should be installed beforehand and activated (see
       below).
-    * `git clone https://github.com/alpaka-group/alpaka.git`
+    * `git clone https://github.com/alpaka-group/alpaka.git --depth 1 
+      --branch 2.1.1`
     * `cd alpaka`
     * `mkdir build && cd build`
-    * `cmake .. -DCMAKE_INSTALL_PREFIX=$ALPAKA_INSTALL_DIR -Dalpaka_ACC_GPU_CUDA_ENABLE=ON`.
+    * `cmake .. -DCMAKE_INSTALL_PREFIX=$ALPAKA_INSTALL_DIR
+      -Dalpaka_ACC_GPU_CUDA_ENABLE=ON`.
       The last option only must be included if acceleration on Nvidia GPUs is
       wanted. Go to the [alpaka manual](https://alpaka.readthedocs.io/en/stable/advanced/cmake.html#arguments)
       for infos on how to use other accelerators.
@@ -177,7 +181,8 @@ The ISAACConfig.cmake searches for these requirements. See
 
 * __libwebsockets__ 2.1.1+ for the connection between server and an HTML5 client:
   * _From Source_:
-    * `git clone https://github.com/warmcat/libwebsockets.git --depth 1 --branch v4.5-stable`
+    * `git clone https://github.com/warmcat/libwebsockets.git --depth 1
+      --branch v4.5-stable`
     * `cd libwebsockets`
     * `mkdir build && cd build`
     * With admin rights and no other version of libwebsockets installed:
@@ -207,7 +212,8 @@ The ISAACConfig.cmake searches for these requirements. See
   streams of a server without gStreamer. If gStreamer is not found, it is
   deactivated by default.
   * _Debian/Ubuntu_:
-    * `sudo apt-get install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libgstreamer-plugins-bad1.0-0`
+    * `sudo apt-get install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0
+      libgstreamer-plugins-good1.0-0 libgstreamer-plugins-bad1.0-0`
 
 Building
 --------


### PR DESCRIPTION
The installation guide was severely outdated. Not anymore!

- updated versions in requirements and install examples
- removed mentioning of running without alpaka, as CUDA-only-mode was removed in #125
- added from-source install for libjpeg-turbo
- OpenMPI now uses builds from website instead of repository
- multiple libraries now use stable releases instead of latest dev
- streamlined all build and install guides for better consistency and (hopefully) readability
- added reference to tunneling for testing the example
- miscellaneous fixes to spelling, changes of line breaks and colons 